### PR TITLE
fix: favicon

### DIFF
--- a/examples/react-app/index.html
+++ b/examples/react-app/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 
 <head>
-  <link rel="icon" href="./logo.png" />
+  <link rel="shortcut icon" type="image/png" href="https://connectors.fuel.network/logo.png" />
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Fuel enables developers to build integrations with any wallet." />


### PR DESCRIPTION
Add the proper URL for the favicon.
Some web applications are not able to get the right URL if we're using relative path.