### PR TITLE
fix: export walletconnect and evm separate

### DIFF
--- a/.changeset/famous-bears-shout.md
+++ b/.changeset/famous-bears-shout.md
@@ -1,0 +1,5 @@
+---
+"@fuels/connectors": minor
+---
+
+fix: bundle only browser-compatible connectors in the main bundle

--- a/examples/react-app/src/main.tsx
+++ b/examples/react-app/src/main.tsx
@@ -13,8 +13,8 @@ import {
   FuelWalletConnector,
   FuelWalletDevelopmentConnector,
   FueletWalletConnector,
-  WalletConnectConnector,
 } from '@fuels/connectors';
+import { WalletConnectConnector } from '@fuels/connectors/walletconnect';
 import { FuelProvider } from '@fuels/react';
 
 import * as Toast from '@radix-ui/react-toast';

--- a/examples/react-next/src/components/Providers.tsx
+++ b/examples/react-next/src/components/Providers.tsx
@@ -7,8 +7,8 @@ import {
   FuelWalletConnector,
   FuelWalletDevelopmentConnector,
   FueletWalletConnector,
-  WalletConnectConnector,
 } from '@fuels/connectors';
+import { WalletConnectConnector } from '@fuels/connectors/walletconnect';
 import { FuelProvider } from '@fuels/react';
 
 const queryClient = new QueryClient();

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -9,6 +9,16 @@
       "require": "./dist/index.js",
       "import": "./dist/index.mjs",
       "types": "./dist/index.d.ts"
+    },
+    "./walletconnect": {
+      "require": "./dist/walletconnect-connector/index.js",
+      "import": "./dist/walletconnect-connector/index.mjs",
+      "types": "./dist/walletconnect-connector/src/index.d.ts"
+    },
+    "./evm": {
+      "require": "./dist/evm-connector/index.js",
+      "import": "./dist/evm-connector/index.mjs",
+      "types": "./dist/evm-connector/src/index.d.ts"
     }
   },
   "files": ["dist"],

--- a/packages/connectors/src/defaultConnectors.ts
+++ b/packages/connectors/src/defaultConnectors.ts
@@ -2,7 +2,6 @@ import { BurnerWalletConnector } from '@fuel-connectors/burner-wallet-connector'
 import { FuelWalletDevelopmentConnector } from '@fuel-connectors/fuel-development-wallet';
 import { FuelWalletConnector } from '@fuel-connectors/fuel-wallet';
 import { FueletWalletConnector } from '@fuel-connectors/fuelet-wallet';
-import { WalletConnectConnector } from '@fuel-connectors/walletconnect-connector';
 import type { FuelConnector } from 'fuels';
 
 type DefaultConnectors = {
@@ -15,7 +14,6 @@ export function defaultConnectors({
   const connectors = [
     new FuelWalletConnector(),
     new FueletWalletConnector(),
-    new WalletConnectConnector(),
     new BurnerWalletConnector(),
   ];
 

--- a/packages/connectors/src/evm-connector/index.ts
+++ b/packages/connectors/src/evm-connector/index.ts
@@ -1,0 +1,1 @@
+export * from '@fuel-connectors/evm-connector';

--- a/packages/connectors/src/index.ts
+++ b/packages/connectors/src/index.ts
@@ -2,6 +2,4 @@ export * from './defaultConnectors';
 export * from '@fuel-connectors/fuel-development-wallet';
 export * from '@fuel-connectors/fuel-wallet';
 export * from '@fuel-connectors/fuelet-wallet';
-export * from '@fuel-connectors/evm-connector';
-export * from '@fuel-connectors/walletconnect-connector';
 export * from '@fuel-connectors/burner-wallet-connector';

--- a/packages/connectors/src/walletconnect-connector/index.ts
+++ b/packages/connectors/src/walletconnect-connector/index.ts
@@ -1,0 +1,1 @@
+export * from '@fuel-connectors/walletconnect-connector';

--- a/packages/connectors/tsup.config.js
+++ b/packages/connectors/tsup.config.js
@@ -3,7 +3,11 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig((options) => ({
   ...baseConfig(options, { withReact: false }),
-  entry: ['src/index.ts'],
+  entry: [
+    'src/index.ts',
+    'src/walletconnect-connector/index.ts',
+    'src/evm-connector/index.ts',
+  ],
   external: ['fuels'],
   noExternal: [
     '@fuel-connectors/fuel-development-wallet',


### PR DESCRIPTION
Since we also use this library in service workers, we can't bundle together libraries that depend on the Node.js environment.

From now on, we'll export `WalletConnect` and `EVM connectors` using a specific-path, example:

```tsx
import { WalletConnectConnector } from '@fuels/connectors/walletconnect';
```