### PR TITLE
chore: remove bakoSafe from `defaultConnectors`

### DIFF
--- a/.changeset/forty-timers-heal.md
+++ b/.changeset/forty-timers-heal.md
@@ -1,5 +1,5 @@
 ---
-"@fuel-connectors/bako-safe": major
+"@fuel-connectors/bako-safe": minor
 ---
 
 Add bako-safe connector

--- a/packages/connectors/src/defaultConnectors.ts
+++ b/packages/connectors/src/defaultConnectors.ts
@@ -1,4 +1,3 @@
-import { BakoSafeConnector } from '@fuel-connectors/bako-safe';
 import { BurnerWalletConnector } from '@fuel-connectors/burner-wallet-connector';
 import { FuelWalletDevelopmentConnector } from '@fuel-connectors/fuel-development-wallet';
 import { FuelWalletConnector } from '@fuel-connectors/fuel-wallet';
@@ -16,7 +15,6 @@ export function defaultConnectors({
   const connectors = [
     new FuelWalletConnector(),
     new FueletWalletConnector(),
-    new BakoSafeConnector(),
     new WalletConnectConnector(),
     new BurnerWalletConnector(),
   ];


### PR DESCRIPTION
- remove bakoSafe from defaultConnectors for now
- revert versioning of `bakoSafe` from major to minor


reasoning is that the connector API is still not stable and sometimes breaking the flow