### PR TITLE
fix: layout fixes in example react-app

### DIFF
--- a/examples/react-app/src/App.tsx
+++ b/examples/react-app/src/App.tsx
@@ -91,7 +91,7 @@ export default function App() {
                 <a
                   href="https://github.com/FuelLabs/fuel-connectors"
                   target="_blank"
-                  className="block pt-4 text-green-500/80 transition-colors hover:text-green-500"
+                  className="inline-block pt-4 text-green-500/80 transition-colors hover:text-green-500"
                   rel="noreferrer"
                 >
                   Build your own wallet integration

--- a/examples/react-app/src/components/notification.tsx
+++ b/examples/react-app/src/components/notification.tsx
@@ -33,13 +33,8 @@ export default function Notification(props: Props) {
               {type === 'success' && 'Success'}
               {type === 'error' && 'Error'}
             </Toast.Title>
-            <Toast.Close className="">
-              <button
-                type="button"
-                className="rounded border border-zinc-500/10 bg-zinc-800 px-1.5 py-[1px] text-sm text-zinc-400"
-              >
-                Close
-              </button>
+            <Toast.Close className="rounded border border-zinc-500/10 bg-zinc-800 px-1.5 py-[1px] text-sm text-zinc-400">
+              Close
             </Toast.Close>
           </div>
           <Toast.Description className={clsx('text-[15px] text-zinc-50/90')}>


### PR DESCRIPTION
- make integration link don't take whole link
- avoid one button inside of other button