### PR TITLE
chore: remove coverage requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:watch": "turbo build:watch",
     "ts:check": "turbo run ts:check",
     "test": "vitest",
-    "test:ci": "turbo run test -- --run --coverage.enabled --coverage.reporter=json-summary --coverage.reporter=json --coverage.thresholds.functions=50 --coverage.thresholds.lines=50 --coverage.thresholds.branches=50 --coverage.thresholds.statements=50",
+    "test:ci": "turbo run test -- --run --coverage.enabled --coverage.reporter=json-summary --coverage.reporter=json",
     "lint:check": "biome check --apply-unsafe .",
     "lint:ci": "biome lint --max-diagnostics=1000 --diagnostic-level=error .",
     "format": "biome format --write .",


### PR DESCRIPTION
Remove this coverage requirements for now as:
- connectors tests are implemented by the own connector, simply having coverage doesn't guarantee that it will work
- next task coming up is to implement a more reliable e2e tests that will guarantee that each connector works. With this we don't need this unit tests inside each connector anymore