### PR TITLE
fix: burner wallet storage incompatibility with Node.js env

### DIFF
--- a/.changeset/thick-squids-compete.md
+++ b/.changeset/thick-squids-compete.md
@@ -1,0 +1,10 @@
+---
+"@fuel-connectors/burner-wallet-connector": patch
+"@fuels/connectors": patch
+---
+
+- [Add support for burner wallet config on default connectors](https://github.com/FuelLabs/fuel-connectors/commit/fb845c0cfdfccfda60637af8d405964e9efbdecb)
+- [Burner wallet storage not working on nodejs](https://github.com/FuelLabs/fuel-connectors/commit/bbf19a2f8b6faeafc5c99055fe2ce2beb2988400)
+- [Create in memory storage on burner wallet](https://github.com/FuelLabs/fuel-connectors/commit/242b24f84f4ac35dba9c1332cb46c80bac5f4766)
+
+Observation: Burner Wallet's Storage will not persist information between executions on Vercel or Node.js env.

--- a/packages/burner-wallet-connector/src/BurnerWalletConnector.ts
+++ b/packages/burner-wallet-connector/src/BurnerWalletConnector.ts
@@ -13,6 +13,7 @@ import {
   Wallet,
   type WalletUnlocked,
 } from 'fuels';
+import { InMemoryStorage } from './InMemoryStorage';
 import {
   BURNER_WALLET_ICON,
   BURNER_WALLET_PRIVATE_KEY,
@@ -88,13 +89,13 @@ export class BurnerWalletConnector extends FuelConnector {
   }
 
   private getStorage(storage?: StorageAbstract) {
-    const _storage =
-      storage ?? (WINDOW.localStorage as unknown as StorageAbstract);
-    if (!_storage) {
-      throw new Error('No storage provided');
+    if (storage) {
+      return storage;
     }
 
-    return _storage;
+    return typeof window !== 'undefined' && window.localStorage
+      ? (window.localStorage as unknown as StorageAbstract)
+      : new InMemoryStorage();
   }
 
   /**

--- a/packages/burner-wallet-connector/src/InMemoryStorage.ts
+++ b/packages/burner-wallet-connector/src/InMemoryStorage.ts
@@ -1,0 +1,26 @@
+import type { StorageAbstract } from 'fuels';
+
+export class InMemoryStorage implements StorageAbstract {
+  private storage: Map<string, string>;
+
+  constructor() {
+    this.storage = new Map<string, string>();
+  }
+
+  async setItem(key: string, value: string): Promise<void> {
+    this.storage.set(key, value);
+  }
+
+  async getItem(key: string): Promise<string | null> {
+    const value = this.storage.get(key);
+    return value !== undefined ? value : null;
+  }
+
+  async removeItem(key: string): Promise<void> {
+    this.storage.delete(key);
+  }
+
+  async clear(): Promise<void> {
+    this.storage.clear();
+  }
+}

--- a/packages/connectors/src/defaultConnectors.ts
+++ b/packages/connectors/src/defaultConnectors.ts
@@ -5,20 +5,23 @@ import { FuelWalletConnector } from '@fuel-connectors/fuel-wallet';
 import { FueletWalletConnector } from '@fuel-connectors/fuelet-wallet';
 import { WalletConnectConnector } from '@fuel-connectors/walletconnect-connector';
 import type { FuelConnector } from 'fuels';
+import type { BurnerWalletConfig } from '../../burner-wallet-connector/src/types';
 
 type DefaultConnectors = {
   devMode?: boolean;
+  burnerWalletConfig?: BurnerWalletConfig;
 };
 
 export function defaultConnectors({
   devMode,
+  burnerWalletConfig,
 }: DefaultConnectors = {}): Array<FuelConnector> {
   const connectors = [
     new FuelWalletConnector(),
     new BakoSafeConnector(),
     new FueletWalletConnector(),
     new WalletConnectConnector(),
-    new BurnerWalletConnector(),
+    new BurnerWalletConnector(burnerWalletConfig),
   ];
 
   if (devMode) {


### PR DESCRIPTION
Closes #107 

- [Add support for burner wallet config on default connectors](https://github.com/FuelLabs/fuel-connectors/commit/fb845c0cfdfccfda60637af8d405964e9efbdecb)
- [Burner wallet storage not working on nodejs](https://github.com/FuelLabs/fuel-connectors/commit/bbf19a2f8b6faeafc5c99055fe2ce2beb2988400)
- [Create in memory storage on burner wallet](https://github.com/FuelLabs/fuel-connectors/commit/242b24f84f4ac35dba9c1332cb46c80bac5f4766)

Observation: Burner Wallet's Storage will not persist information between executions on Vercel or Node.js env.

Successful Explorer build with Burner Wallet enabled, using this PR's tag:
https://vercel.com/fuel-labs/fuel-explorer/Goc1QWM49AGSHvhTiF2xUbxYhFJA