### PR TITLE
fix: sort installed connectors correctly

### DIFF
--- a/packages/react/src/providers/FuelUIProvider.tsx
+++ b/packages/react/src/providers/FuelUIProvider.tsx
@@ -63,10 +63,13 @@ const sortConnectors = (connectors: FuelConnector[]): FuelConnector[] => {
       return a.connected ? -1 : 1;
     }
 
+    // Use temporary variables to represent "installed" status for sorting
     const aIsBlacklisted = BADGE_BLACKLIST.includes(a.name);
     const bIsBlacklisted = BADGE_BLACKLIST.includes(b.name);
-    if (!aIsBlacklisted && !bIsBlacklisted && a.installed !== b.installed) {
-      return a.installed ? -1 : 1;
+    const aInstalled = aIsBlacklisted ? false : a.installed;
+    const bInstalled = bIsBlacklisted ? false : b.installed;
+    if (aInstalled !== bInstalled) {
+      return aInstalled ? -1 : 1;
     }
 
     return a.name.localeCompare(b.name);


### PR DESCRIPTION
- Relates to https://github.com/FuelLabs/fuel-connectors/issues/247

---

It was missing to sort the `installed` only if it's not a "external" connector.