### PR TITLE
fix: render connect modal using portal

### DIFF
--- a/.changeset/proud-books-think.md
+++ b/.changeset/proud-books-think.md
@@ -1,0 +1,5 @@
+---
+"@fuels/react": patch
+---
+
+Render `Connect` modal using React.Portal in order to have a consistent modal stacking in external projects.

--- a/packages/react/src/ui/Connect/index.tsx
+++ b/packages/react/src/ui/Connect/index.tsx
@@ -1,7 +1,5 @@
 import * as Dialog from '@radix-ui/react-dialog';
-import { useEffect, useRef, useState } from 'react';
-
-import './index.css';
+import { useEffect, useState } from 'react';
 
 import { useConnectUI } from '../../providers/FuelUIProvider';
 
@@ -19,12 +17,13 @@ import {
 } from './styles';
 import { getThemeVariables } from './themes';
 
+import './index.css';
+
 export function Connect() {
   // Fix hydration problem between nextjs render and frontend render
   // UI was not getting updated and theme colors was set wrongly
   // see more here https://nextjs.org/docs/messages/react-hydration-error
   const [isClient, setIsClient] = useState(false);
-  const containerRef = useRef<HTMLDivElement | null>(null);
   const {
     theme,
     cancel,
@@ -40,34 +39,37 @@ export function Connect() {
   };
 
   return (
-    <>
-      <FuelRoot
-        ref={containerRef}
-        style={
-          isClient
-            ? {
-                display: isOpen ? 'block' : 'none',
-                ...getThemeVariables(theme),
-              }
-            : undefined
-        }
-      />
-      <Dialog.Root open={isOpen} onOpenChange={handleOpenChange}>
-        <Dialog.Portal container={containerRef.current}>
-          <DialogOverlay />
-          <DialogContent data-connector={!!connector}>
-            <DialogTitle>Connect Wallet</DialogTitle>
-            <Divider />
-            <Dialog.Close asChild>
-              <CloseIcon size={32} />
-            </Dialog.Close>
-            <BackIcon size={32} onClick={back} data-connector={!!connector} />
-            <DialogMain>
-              {connector ? <Connector connector={connector} /> : <Connectors />}
-            </DialogMain>
-          </DialogContent>
-        </Dialog.Portal>
-      </Dialog.Root>
-    </>
+    <Dialog.Root open={isOpen} onOpenChange={handleOpenChange}>
+      <Dialog.Portal>
+        <DialogOverlay asChild>
+          <FuelRoot
+            style={
+              isClient
+                ? {
+                    display: isOpen ? 'block' : 'none',
+                    ...getThemeVariables(theme),
+                  }
+                : undefined
+            }
+          >
+            <DialogContent data-connector={!!connector}>
+              <DialogTitle>Connect Wallet</DialogTitle>
+              <Divider />
+              <Dialog.Close asChild>
+                <CloseIcon size={32} />
+              </Dialog.Close>
+              <BackIcon size={32} onClick={back} data-connector={!!connector} />
+              <DialogMain>
+                {connector ? (
+                  <Connector connector={connector} />
+                ) : (
+                  <Connectors />
+                )}
+              </DialogMain>
+            </DialogContent>
+          </FuelRoot>
+        </DialogOverlay>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 }

--- a/packages/react/src/ui/Connect/styles.tsx
+++ b/packages/react/src/ui/Connect/styles.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import * as Dialog from '@radix-ui/react-dialog';
 import { keyframes, styled } from 'styled-components';
 


### PR DESCRIPTION
The `Connect` modal had a `z-index` issue because it was rendered directly inside the actual content in the`body`. 
This caused it to be `hidden` behind other dialogs that use `Portals` in external projects.

---

| 📷 Demo |
| --- |
| <img width="573" alt="Screenshot 2024-09-20 at 13 18 10" src="https://github.com/user-attachments/assets/01b57f32-1ba8-44a3-8baa-745abe04ce88"> |

