### PR TITLE
fix: dialog overlap

### DIFF
--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -20,3 +20,4 @@ export * from './useTransaction';
 export * from './useTransactionReceipts';
 export * from './useTransactionResult';
 export * from './useWallet';
+export * from './useSelectConnectorNetwork';

--- a/packages/react/src/hooks/useNetworkPaired.tsx
+++ b/packages/react/src/hooks/useNetworkPaired.tsx
@@ -1,0 +1,37 @@
+import { useMemo, useState } from 'react';
+import { NATIVE_CONNECTORS } from '../config';
+import { useFuel, useFuelChain } from '../providers';
+import { useWallet } from './useWallet';
+
+/**
+ * A hook to check if the current network is paired with the wallet.
+ *
+ * @returns {boolean | null} - Returns true if the network is paired with the wallet, false if not, or null if the connector is not valid.
+ * @examples
+ * ```ts
+ * const networkPaired = useNetworkPaired();
+ * console.log(networkPaired);
+ * ```
+ */
+export function useNetworkPaired() {
+  const { fuel } = useFuel();
+  const { wallet } = useWallet();
+  const { chainId } = useFuelChain();
+  const walletChainId = wallet?.provider.getChainId();
+
+  const currentConnector = fuel.currentConnector();
+  // Fix hydration problem between nextjs render and frontend render
+  // UI was not getting updated and theme colors was set wrongly
+  // see more here https://nextjs.org/docs/messages/react-hydration-error
+  const validConnector =
+    !!currentConnector &&
+    NATIVE_CONNECTORS.includes(currentConnector?.name) &&
+    currentConnector.connected;
+
+  return useMemo(() => {
+    if (!validConnector || walletChainId == null) {
+      return null;
+    }
+    return walletChainId === chainId;
+  }, [chainId, validConnector, walletChainId]);
+}

--- a/packages/react/src/hooks/useSelectConnectorNetwork.ts
+++ b/packages/react/src/hooks/useSelectConnectorNetwork.ts
@@ -1,0 +1,38 @@
+import { useMutation } from '@tanstack/react-query';
+import type { FuelConnector } from 'fuels';
+
+/**
+ * A hook to select a network in the connector.
+ *
+ * @returns {object} An object containing:
+ * - `selectNetwork`: function to add a network synchronously.
+ * - `selectNetworkAsync` function to add a network asynchronously.
+ * - {@link https://tanstack.com/query/latest/docs/framework/react/reference/useMutation | `...mutationProps`}: Destructured properties from `useMutation` result.
+ *
+ * @examples
+ *  To select a network synchronously:
+ * ```ts
+ * const { selectNetwork } = useSelectNetwork();
+ * selectNetwork(network);
+ * ```
+ *
+ * To select a network asynchronously:
+ * ```ts
+ * const { selectNetworkAsync } = useSelectNetwork();
+ * await selectNetworkAsync(network);
+ * ```
+ *
+ */
+export const useSelectConnectorNetwork = (
+  connector: FuelConnector | undefined | null,
+) => {
+  const { mutate, mutateAsync, ...queryProps } = useMutation({
+    mutationFn: connector?.selectNetwork,
+  });
+
+  return {
+    selectNetwork: mutate,
+    selectNetworkAsync: mutateAsync,
+    ...queryProps,
+  };
+};

--- a/packages/react/src/hooks/useSelectConnectorNetwork.ts
+++ b/packages/react/src/hooks/useSelectConnectorNetwork.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import type { FuelConnector } from 'fuels';
+import type { FuelConnector, SelectNetworkArguments } from 'fuels';
 
 /**
  * A hook to select a network in the connector.
@@ -27,7 +27,8 @@ export const useSelectConnectorNetwork = (
   connector: FuelConnector | undefined | null,
 ) => {
   const { mutate, mutateAsync, ...queryProps } = useMutation({
-    mutationFn: connector?.selectNetwork,
+    mutationFn: (network: SelectNetworkArguments) =>
+      connector ? connector?.selectNetwork(network) : Promise.reject(undefined),
   });
 
   return {

--- a/packages/react/src/ui/Connect/index.tsx
+++ b/packages/react/src/ui/Connect/index.tsx
@@ -17,6 +17,8 @@ import {
 
 import type { FuelConnector } from 'fuels';
 import { getThemeVariables } from '../../constants/themes';
+import { useNetworkPaired } from '../../hooks/useNetworkPaired';
+import { useFuel } from '../../providers';
 import { DialogContent } from '../Dialog/components/Content';
 import { Bridge } from './components/Bridge/Bridge';
 import { Connecting } from './components/Connector/Connecting';
@@ -61,6 +63,15 @@ export function Connect() {
     bridgeURL,
     dialog: { isOpen, route: state, connector, back },
   } = useConnectUI();
+  const { fuel } = useFuel();
+  const currentConnector = fuel.currentConnector();
+  const networkPaired = useNetworkPaired();
+
+  useEffect(() => {
+    if (currentConnector?.connected === false) {
+      cancel();
+    }
+  }, [currentConnector?.connected, cancel]);
 
   useEffect(() => {
     setIsClient(true);
@@ -71,7 +82,10 @@ export function Connect() {
   };
 
   return (
-    <Dialog.Root open={isOpen} onOpenChange={handleOpenChange}>
+    <Dialog.Root
+      open={isOpen && networkPaired !== false}
+      onOpenChange={handleOpenChange}
+    >
       <Dialog.Portal>
         <DialogOverlay asChild>
           <FuelRoot

--- a/packages/react/src/ui/NetworkMonitor/components/NetworkSwitchDialog/index.tsx
+++ b/packages/react/src/ui/NetworkMonitor/components/NetworkSwitchDialog/index.tsx
@@ -53,7 +53,9 @@ export function NetworkSwitchDialog({
   }`;
 
   function handleSwitch() {
-    chainId != null && selectNetwork({ chainId }, { onSuccess: close });
+    chainId != null &&
+      !!currentConnector?.connected &&
+      selectNetwork({ chainId });
   }
 
   function handleDisconnect() {

--- a/packages/react/src/ui/NetworkMonitor/components/NetworkSwitchDialog/index.tsx
+++ b/packages/react/src/ui/NetworkMonitor/components/NetworkSwitchDialog/index.tsx
@@ -1,7 +1,8 @@
 import type { FuelConnector } from 'fuels';
 import { useMemo } from 'react';
 import { NATIVE_CONNECTORS } from '../../../../config';
-import { useSelectNetwork } from '../../../../hooks/useSelectNetwork';
+
+import { useSelectConnectorNetwork } from '../../../../hooks/useSelectConnectorNetwork';
 import { Spinner } from '../../../../icons/Spinner';
 import { useFuelChain } from '../../../../providers';
 import {
@@ -22,7 +23,10 @@ export function NetworkSwitchDialog({
   close,
 }: { currentConnector: FuelConnector | undefined | null; close: () => void }) {
   const { chainId } = useFuelChain();
-  const { selectNetwork, isError, error, isPending } = useSelectNetwork();
+
+  const { selectNetwork, isError, error, isPending } =
+    useSelectConnectorNetwork(currentConnector);
+
   const canSwitch = useMemo(
     () =>
       currentConnector?.name &&


### PR DESCRIPTION

- Fix `Connect`'s dialog overlapping with NetworkMonitor's
- Created a `useSelectConnectorNetwork` hook
- Extracted network sync logic to hook