### PR TITLE
fix: ensure user is already connected 

### DIFF
--- a/.changeset/shy-timers-doubt.md
+++ b/.changeset/shy-timers-doubt.md
@@ -1,0 +1,5 @@
+---
+"@fuels/react": patch
+---
+
+Ensure the `Connect popup` is displayed only if the user is not already connected.

--- a/packages/react/src/ui/Connect/components/Connector/Connecting.tsx
+++ b/packages/react/src/ui/Connect/components/Connector/Connecting.tsx
@@ -1,7 +1,7 @@
 import { Routes, useConnectUI } from '../../../../providers/FuelUIProvider';
 import { ConnectorIcon } from '../Core/ConnectorIcon';
 
-import { useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
 import { Spinner } from '../../../../icons/Spinner';
 import {
   ConnectorButton,
@@ -27,17 +27,13 @@ export function Connecting({ className }: ConnectorProps) {
     isConnected,
   } = useConnectUI();
 
-  if (!connector) return null;
+  useEffect(() => {
+    if (isConnected && route === Routes.CONNECTING && !isConnecting) {
+      cancel();
+    }
+  }, [isConnected, route, isConnecting, cancel]);
 
-  useQuery({
-    queryKey: ['CONNECTING', connector.name, route, isConnected, isConnecting],
-    queryFn: async () => {
-      if (isConnected && route === Routes.CONNECTING && !isConnecting) {
-        cancel();
-      }
-      return null;
-    },
-  });
+  if (!connector) return null;
 
   return (
     <div className={className}>

--- a/packages/react/src/ui/Connect/components/Connector/Connector.tsx
+++ b/packages/react/src/ui/Connect/components/Connector/Connector.tsx
@@ -1,8 +1,6 @@
-import type { FuelConnector } from 'fuels';
-
 import { ConnectorIcon } from '../Core/ConnectorIcon';
 
-import { useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
 import { useConnectUI } from '../../../../providers';
 import { Routes } from '../../../../providers/FuelUIProvider';
 import {
@@ -25,15 +23,14 @@ export function Connector() {
   } = connector.metadata;
 
   // Ping extension: if it's installed, it will trigger connector
-  useQuery({
-    queryKey: ['CONNECTOR_PING', connector.name, connector.installed],
-    queryFn: async () => {
-      const isInstall = await connector.ping();
-      if (isInstall) setRoute(Routes.CONNECTING);
-      return isInstall;
-    },
-    staleTime: Number.POSITIVE_INFINITY,
-  });
+  useEffect(() => {
+    const ping = async () => {
+      const isInstalled = await connector.ping();
+      if (isInstalled) setRoute(Routes.CONNECTING);
+    };
+
+    ping();
+  }, [connector, setRoute]);
 
   const actionText = action || 'Install';
 


### PR DESCRIPTION
- Closes https://github.com/FuelLabs/fuel-connectors/issues/300

---

The issue was caused by relying on the react-query cache, which could lead to inconsistencies since app consumers might have custom configurations.

I also took the opportunity to replace those simple `useQueries` with `useEffect`, as it’s a better and safer approach for this case.
