### PR TITLE
fix: FuelProvider leaking render events

### DIFF
--- a/.changeset/brave-students-boil.md
+++ b/.changeset/brave-students-boil.md
@@ -1,0 +1,5 @@
+---
+"@fuels/react": patch
+---
+
+Fixed FuelProvider triggering unnecessary render events

--- a/examples/react-app/src/main.tsx
+++ b/examples/react-app/src/main.tsx
@@ -52,29 +52,25 @@ const wagmiConfig = createConfig({
     }),
   ],
 });
+const NETWORKS = [
+  {
+    chainId: CHAIN_IDS.fuel.testnet,
+  },
+];
+
+const FUEL_CONFIG = {
+  connectors: defaultConnectors({
+    devMode: true,
+    wcProjectId: WC_PROJECT_ID,
+    ethWagmiConfig: wagmiConfig,
+    chainId: CHAIN_IDS.fuel.testnet,
+  }),
+};
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
-      <FuelProvider
-        theme="dark"
-        uiConfig={{
-          suggestBridge: true, // default true
-        }}
-        networks={[
-          {
-            chainId: CHAIN_IDS.fuel.testnet,
-          },
-        ]}
-        fuelConfig={{
-          connectors: defaultConnectors({
-            devMode: true,
-            wcProjectId: WC_PROJECT_ID,
-            ethWagmiConfig: wagmiConfig,
-            chainId: CHAIN_IDS.fuel.testnet,
-          }),
-        }}
-      >
+      <FuelProvider theme="dark" networks={NETWORKS} fuelConfig={FUEL_CONFIG}>
         <Toast.Provider>
           <App />
           <Toast.Viewport

--- a/packages/react/src/providers/FuelProvider.tsx
+++ b/packages/react/src/providers/FuelProvider.tsx
@@ -2,6 +2,7 @@ import type { FuelConfig } from 'fuels';
 
 import { Connect } from '../ui/Connect';
 
+import { useMemo } from 'react';
 import type { NetworkConfig, UIConfig } from '../types';
 import { BridgeDialog } from '../ui/Connect/components/Bridge/BridgeDialog';
 import { NetworkDialog } from '../ui/Connect/components/Network/NetworkDialog';
@@ -29,11 +30,15 @@ export function FuelProvider({
 }: FuelProviderProps) {
   const theme = _theme || 'light';
   const networksConfig = useNetworkConfigs(networks);
-  const uiConfig = Object.assign(
-    {
-      suggestBridge: true,
-    },
-    _uiConfig ?? {},
+  const uiConfig = useMemo(
+    () =>
+      Object.assign(
+        {
+          suggestBridge: true,
+        },
+        _uiConfig ?? {},
+      ),
+    [_uiConfig],
   );
 
   if (ui) {

--- a/packages/react/src/providers/FuelUIProvider.tsx
+++ b/packages/react/src/providers/FuelUIProvider.tsx
@@ -124,11 +124,11 @@ export function FuelUIProvider({
     }
   }, [connectors, connector]);
 
-  const handleBack = () => {
+  const handleBack = useCallback(() => {
     setError(null);
     setConnector(null);
     setDialogRoute(Routes.LIST);
-  };
+  }, []);
 
   const handleRetryConnect = useCallback(
     async (connector: FuelConnector) => {
@@ -203,38 +203,61 @@ export function FuelUIProvider({
     };
   }, []);
 
+  const contextValue = useMemo(
+    () => ({
+      // General
+      theme: theme || 'light',
+      fuelConfig,
+      uiConfig,
+      error,
+      setError,
+      // Connection
+      isConnected: !!isConnected,
+      isConnecting,
+      // UI States
+      isLoading,
+      isError,
+      connectors,
+      // Actions
+      connect: handleConnect,
+      cancel: handleCancel,
+      // Dialog only
+      dialog: {
+        route: dialogRoute,
+        setRoute,
+        connector,
+        isOpen,
+        connect: handleSelectConnector,
+        retryConnect: handleRetryConnect,
+        back: handleBack,
+        _startConnection: handleStartConnection,
+      },
+    }),
+    [
+      theme,
+      fuelConfig,
+      uiConfig,
+      error,
+      isConnected,
+      isConnecting,
+      isLoading,
+      isError,
+      connectors,
+      connector,
+      dialogRoute,
+      isOpen,
+      handleCancel,
+      handleStartConnection,
+      setRoute,
+      handleSelectConnector,
+      handleConnect,
+      handleRetryConnect,
+      handleBack,
+    ],
+  );
+
   return (
-    <FuelConnectContext.Provider
-      value={{
-        // General
-        theme: theme || 'light',
-        fuelConfig,
-        uiConfig,
-        error,
-        setError,
-        // Connection
-        isConnected: !!isConnected,
-        isConnecting,
-        // UI States
-        isLoading,
-        isError,
-        connectors,
-        // Actions
-        connect: handleConnect,
-        cancel: handleCancel,
-        // Dialog only
-        dialog: {
-          route: dialogRoute,
-          setRoute,
-          connector,
-          isOpen,
-          connect: handleSelectConnector,
-          retryConnect: handleRetryConnect,
-          back: handleBack,
-          _startConnection: handleStartConnection,
-        },
-      }}
-    >
+    <FuelConnectContext.Provider value={contextValue}>
       {children}
     </FuelConnectContext.Provider>
   );


### PR DESCRIPTION

- If a dynamically created obj (i.e. loosely created during render) is passed to a Providers's Context, it triggers a new render on all children + components accessing the context via `useContext`. It can also trigger unnecessary cycles in useMemo/useCallback/useEffect that uses properties from the context.
- Wrapped Provider's obj data + dependencies in useMemo/useCallback