### PR TITLE
fix: conflicts with connected status in the cache engine

### DIFF
--- a/.changeset/beige-peaches-burn.md
+++ b/.changeset/beige-peaches-burn.md
@@ -1,0 +1,5 @@
+---
+"@fuels/react": patch
+---
+
+Replace `initialData` with `placeholderData` to avoid conflicts with `useQuery` cache engine.

--- a/packages/react/src/core/useNamedQuery.ts
+++ b/packages/react/src/core/useNamedQuery.ts
@@ -1,10 +1,8 @@
 import type {
   DefaultError,
-  DefinedInitialDataOptions,
   DefinedUseQueryResult,
   QueryClient,
   QueryKey,
-  UndefinedInitialDataOptions,
   UseQueryOptions,
   UseQueryResult,
 } from '@tanstack/react-query';
@@ -12,14 +10,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 
 type ExcludeData<T> = Omit<T, 'data'>;
-
-type NamedUseQueryResult<
-  TName extends string,
-  TQueryFnData = unknown,
-  TError = DefaultError,
-> = ExcludeData<UseQueryResult<TQueryFnData, TError>> & {
-  [key in TName]: UseQueryResult<TQueryFnData, TError>['data'];
-};
+type ExcludePlaceholderData<T> = Omit<T, 'placeholderData'>;
 
 export type DefinedNamedUseQueryResult<
   TName extends string,
@@ -30,8 +21,8 @@ export type DefinedNamedUseQueryResult<
 };
 
 /**
- * TanStack Query parameters, like queryFn and queryKey, are used internally and you cannot override them.
- * Currently we're exporting only "select" function.
+ * TanStack Query parameters for external usage.
+ * Parameters like `queryFn` and `queryKey` are used internally and you cannot override them.
  *
  * See docs for more information: https://tanstack.com/query/latest/docs/framework/react/reference/useQuery
  */
@@ -43,9 +34,31 @@ export interface UseNamedQueryParams<
   TQueryKey extends QueryKey = QueryKey,
 > extends Omit<
     UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-    'queryKey' | 'queryFn' | 'enabled' | 'initialData'
+    'queryKey' | 'queryFn' | 'enabled' | 'initialData' | 'placeholderData'
   > {
   name?: TName;
+}
+
+/**
+ * TanStack Query parameters for internal usage (inside @fuels/react).
+ * This is only used for making the `placeholderData` property required.
+ *
+ * See docs for more information: https://tanstack.com/query/latest/docs/framework/react/reference/useQuery
+ */
+interface UseNamedQueryOptions<
+  TQueryFnData = unknown,
+  TError = DefaultError,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+> extends ExcludePlaceholderData<
+    UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>
+  > {
+  placeholderData: UseQueryOptions<
+    TQueryFnData,
+    TError,
+    TData,
+    TQueryKey
+  >['placeholderData'];
 }
 
 function createProxyHandler<
@@ -56,7 +69,11 @@ function createProxyHandler<
   const handlers: ProxyHandler<UseQueryResult<TData, TError>> = {
     get(target, prop) {
       const shouldReplaceData = prop === name;
-      return Reflect.get(target, shouldReplaceData ? 'data' : prop);
+      if (shouldReplaceData) {
+        return Reflect.get(target, 'data');
+      }
+
+      return Reflect.get(target, prop);
     },
   };
 
@@ -64,42 +81,10 @@ function createProxyHandler<
 }
 
 /**
- * When initialData is not provided "data" will be always TQueryFnData | undefined.
- * It might need some type checking to be sure that the data is not undefined.
- */
-export function useNamedQuery<
-  TName extends string,
-  TQueryFnData = unknown,
-  TError = DefaultError,
-  TData = TQueryFnData,
-  TQueryKey extends QueryKey = QueryKey,
->(
-  name: TName,
-  options: UndefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
-  queryClient?: QueryClient,
-): NamedUseQueryResult<TName, TData, TError>;
-
-/**
- * When initialData is provided "data" will be always TQueryFnData.
- * Never undefined.
- */
-export function useNamedQuery<
-  TName extends string,
-  TQueryFnData = unknown,
-  TError = DefaultError,
-  TData = TQueryFnData,
-  TQueryKey extends QueryKey = QueryKey,
->(
-  name: TName,
-  options: DefinedInitialDataOptions<TQueryFnData, TError, TData, TQueryKey>,
-  queryClient?: QueryClient,
-): DefinedNamedUseQueryResult<TName, TData, TError>;
-
-/**
  * useNamedQuery is a wrapper for useQuery that allows you to override the "data" property with a custom name.
  *
  * @param name a identifier to override "data" property with this name
- * @param options UseQueryOptions
+ * @param options UseNamedQueryOptions
  * @returns useQuery
  */
 export function useNamedQuery<
@@ -110,17 +95,16 @@ export function useNamedQuery<
   TQueryKey extends QueryKey = QueryKey,
 >(
   name: TName,
-  options: UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+  options: UseNamedQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
   queryClient?: QueryClient,
-): NamedUseQueryResult<TName, TData, TError> {
+): DefinedNamedUseQueryResult<TName, TData, TError> {
   const query = useQuery(options, queryClient);
 
   const proxy = useMemo(() => {
-    return new Proxy(query, createProxyHandler(name)) as NamedUseQueryResult<
-      TName,
-      TData,
-      TError
-    >;
+    return new Proxy(
+      query,
+      createProxyHandler(name),
+    ) as DefinedNamedUseQueryResult<TName, TData, TError>;
   }, [name, query]);
 
   return proxy;

--- a/packages/react/src/hooks/useAccount.ts
+++ b/packages/react/src/hooks/useAccount.ts
@@ -31,8 +31,12 @@ export const useAccount = (
   return useNamedQuery('account', {
     queryKey: QUERY_KEYS.account(),
     queryFn: async () => {
-      const currentFuelAccount = await fuel?.currentAccount();
-      return currentFuelAccount;
+      try {
+        const currentFuelAccount = await fuel?.currentAccount();
+        return currentFuelAccount;
+      } catch (_error: unknown) {
+        return null;
+      }
     },
     placeholderData: null,
     ...params?.query,

--- a/packages/react/src/hooks/useAccount.ts
+++ b/packages/react/src/hooks/useAccount.ts
@@ -31,14 +31,10 @@ export const useAccount = (
   return useNamedQuery('account', {
     queryKey: QUERY_KEYS.account(),
     queryFn: async () => {
-      try {
-        const currentFuelAccount = await fuel?.currentAccount();
-        return currentFuelAccount;
-      } catch (_error: unknown) {
-        return null;
-      }
+      const currentFuelAccount = await fuel?.currentAccount();
+      return currentFuelAccount;
     },
-    initialData: null,
+    placeholderData: null,
     ...params?.query,
   });
 };

--- a/packages/react/src/hooks/useAccounts.ts
+++ b/packages/react/src/hooks/useAccounts.ts
@@ -38,7 +38,7 @@ export const useAccounts = (
         return [];
       }
     },
-    initialData: [],
+    placeholderData: [],
     ...params?.query,
   });
 };

--- a/packages/react/src/hooks/useAssets.ts
+++ b/packages/react/src/hooks/useAssets.ts
@@ -37,7 +37,7 @@ export const useAssets = (params?: UseAssetsParams<'assets', Asset[]>) => {
         return [];
       }
     },
-    initialData: [],
+    placeholderData: [],
     ...params?.query,
   });
 };

--- a/packages/react/src/hooks/useBalance.ts
+++ b/packages/react/src/hooks/useBalance.ts
@@ -53,7 +53,7 @@ export const useBalance = ({
   const { provider } = useProvider();
   const _address = account ?? address ?? undefined;
 
-  const result = useNamedQuery('balance', {
+  return useNamedQuery('balance', {
     queryKey: QUERY_KEYS.balance(_address, assetId, provider),
     queryFn: async () => {
       try {
@@ -69,10 +69,8 @@ export const useBalance = ({
         return null;
       }
     },
-    initialData: null,
+    placeholderData: null,
     enabled: !!provider && !!_address,
     ...query,
   });
-
-  return result;
 };

--- a/packages/react/src/hooks/useChain.ts
+++ b/packages/react/src/hooks/useChain.ts
@@ -44,7 +44,7 @@ export const useChain = (
         return null;
       }
     },
-    initialData: null,
+    placeholderData: null,
     enabled: !!provider,
     ...params?.query,
   });

--- a/packages/react/src/hooks/useConnectors.ts
+++ b/packages/react/src/hooks/useConnectors.ts
@@ -41,7 +41,7 @@ export const useConnectors = <
     queryFn: async () => {
       return fuel.connectors();
     },
-    initialData: [],
+    placeholderData: [],
     ...query,
   });
 };

--- a/packages/react/src/hooks/useContractRead.ts
+++ b/packages/react/src/hooks/useContractRead.ts
@@ -116,5 +116,6 @@ export const useContractRead = <
         ? contract.functions[functionName](args)
         : contract.functions[functionName]();
     },
+    placeholderData: undefined,
   });
 };

--- a/packages/react/src/hooks/useCurrentConnector.tsx
+++ b/packages/react/src/hooks/useCurrentConnector.tsx
@@ -42,6 +42,7 @@ export const useCurrentConnector = <
       if (!isConnected) return null;
       return fuel.currentConnector() ?? null;
     },
+    placeholderData: null,
     ...query,
   });
 };

--- a/packages/react/src/hooks/useIsConnected.ts
+++ b/packages/react/src/hooks/useIsConnected.ts
@@ -35,7 +35,7 @@ export const useIsConnected = (params?: UseIsConnected) => {
         return false;
       }
     },
-    initialData: false,
+    placeholderData: false,
     ...params?.query,
     // This is required for now as Fuelet is not triggering the connection event
     refetchInterval: 1000,

--- a/packages/react/src/hooks/useIsSupportedNetwork.tsx
+++ b/packages/react/src/hooks/useIsSupportedNetwork.tsx
@@ -47,7 +47,7 @@ export function useIsSupportedNetwork(params?: UseIsSupportedNetwork) {
       }
       return !!networks.find((n) => n.chainId === chainId);
     },
-    initialData: true,
+    placeholderData: true,
     ...params,
   });
 }

--- a/packages/react/src/hooks/useNetwork.ts
+++ b/packages/react/src/hooks/useNetwork.ts
@@ -33,7 +33,7 @@ export const useNetwork = (params?: UseNetwork) => {
     queryFn: async () => {
       return fuel.currentNetwork();
     },
-    initialData: null,
+    placeholderData: null,
     ...params?.query,
   });
 };

--- a/packages/react/src/hooks/useNetworks.ts
+++ b/packages/react/src/hooks/useNetworks.ts
@@ -36,6 +36,7 @@ export const useNetworks = (params?: UseNetworkParams) => {
   return useNamedQuery('networks', {
     queryKey: QUERY_KEYS.networks(),
     queryFn: fuel.networks,
+    placeholderData: [],
     ...params?.query,
   });
 };

--- a/packages/react/src/hooks/useNodeInfo.ts
+++ b/packages/react/src/hooks/useNodeInfo.ts
@@ -56,7 +56,7 @@ export const useNodeInfo = ({
         return null;
       }
     },
-    initialData: null,
+    placeholderData: null,
     enabled: !!provider,
     ...queryParams,
   });

--- a/packages/react/src/hooks/useProvider.ts
+++ b/packages/react/src/hooks/useProvider.ts
@@ -55,7 +55,7 @@ export const useProvider = (params?: UseProviderParams) => {
       }
       return provider;
     },
-    initialData: null,
+    placeholderData: null,
     ...params?.query,
   });
 };

--- a/packages/react/src/hooks/useTransaction.ts
+++ b/packages/react/src/hooks/useTransaction.ts
@@ -38,7 +38,7 @@ export const useTransaction = (txId?: string) => {
         return null;
       }
     },
-    initialData: null,
+    placeholderData: null,
     enabled: !!txId,
   });
 };

--- a/packages/react/src/hooks/useTransactionReceipts.ts
+++ b/packages/react/src/hooks/useTransactionReceipts.ts
@@ -52,7 +52,7 @@ export const useTransactionReceipts = <TTransactionType = void>({
         return null;
       }
     },
-    initialData: null,
+    placeholderData: null,
     enabled: !!txId,
     ...query,
   });

--- a/packages/react/src/hooks/useTransactionResult.ts
+++ b/packages/react/src/hooks/useTransactionResult.ts
@@ -71,7 +71,7 @@ export const useTransactionResult = <
 
       return data || null;
     },
-    initialData: null,
+    placeholderData: null,
     enabled: !!txId,
     ...options,
   });

--- a/packages/react/src/hooks/useWallet.ts
+++ b/packages/react/src/hooks/useWallet.ts
@@ -78,7 +78,7 @@ export function useWallet(
         return null;
       }
     },
-    initialData: null,
+    placeholderData: null,
     ..._params.query,
   });
 }


### PR DESCRIPTION
- Closes https://github.com/FuelLabs/fuel-connectors/issues/322

---

As per the official [React Query documentation](https://tanstack.com/query/latest/docs/framework/react/guides/initial-query-data#using-initialdata-to-prepopulate-a-query), `initialData` is not intended for prepopulating queries, as it persists data in the cache.

This is important because when a consumer app configures a `QueryClient` with `staleTime: Infinity`, the data won't be refetched, even when components re-render. This behavior is due to how react-query handles its cache mechanism.

To properly set initial (but pending) data, the correct method is to use `placeholderData` instead.

Also, to complement that, I did a small update in the `useNamedQuery` to keep our typescript definitions compatible everywhere.

