### PR TITLE
fix: delay start of current connector

### DIFF
--- a/.changeset/gorgeous-dingos-study.md
+++ b/.changeset/gorgeous-dingos-study.md
@@ -1,0 +1,5 @@
+---
+"@fuels/react": patch
+---
+
+Fix delay start of current connector

--- a/packages/docs/.typedoc/hooks-links.json
+++ b/packages/docs/.typedoc/hooks-links.json
@@ -19,21 +19,13 @@
     "link": "/guide/react-hooks/useAddNetwork",
     "items": []
   },
-  {
-    "text": "useAssets",
-    "link": "/guide/react-hooks/useAssets",
-    "items": []
-  },
+  { "text": "useAssets", "link": "/guide/react-hooks/useAssets", "items": [] },
   {
     "text": "useBalance",
     "link": "/guide/react-hooks/useBalance",
     "items": []
   },
-  {
-    "text": "useChain",
-    "link": "/guide/react-hooks/useChain",
-    "items": []
-  },
+  { "text": "useChain", "link": "/guide/react-hooks/useChain", "items": [] },
   {
     "text": "useConnect",
     "link": "/guide/react-hooks/useConnect",
@@ -114,9 +106,5 @@
     "link": "/guide/react-hooks/useTransactionResult",
     "items": []
   },
-  {
-    "text": "useWallet",
-    "link": "/guide/react-hooks/useWallet",
-    "items": []
-  }
+  { "text": "useWallet", "link": "/guide/react-hooks/useWallet", "items": [] }
 ]

--- a/packages/react/src/providers/FuelHooksProvider.tsx
+++ b/packages/react/src/providers/FuelHooksProvider.tsx
@@ -1,9 +1,10 @@
 import type { FuelConfig } from 'fuels';
 import { Fuel } from 'fuels';
 import type { ReactNode } from 'react';
-import { createContext, useContext, useMemo } from 'react';
+import { createContext, useContext, useMemo, useRef } from 'react';
 
 import type { NetworkConfig } from '../types';
+import { useWindowConnectorEvent } from '../utils/useWindowConnectorEvent';
 import { FuelEventsWatcher } from './FuelEventsWatcher';
 
 type FuelProviderProps = {
@@ -34,9 +35,16 @@ export const FuelHooksProvider = ({
   fuelConfig,
   networks,
 }: FuelProviderProps) => {
+  const fuelRef = useRef<Fuel | null>(null);
   const fuel = useMemo(() => {
-    return new Fuel(fuelConfig);
+    if (fuelRef.current) {
+      fuelRef.current?.destroy();
+    }
+    fuelRef.current = new Fuel(fuelConfig);
+    return fuelRef.current;
   }, [fuelConfig]);
+
+  useWindowConnectorEvent(fuel);
 
   return (
     <FuelReactContext.Provider value={{ fuel, networks }}>

--- a/packages/react/src/providers/FuelProvider.tsx
+++ b/packages/react/src/providers/FuelProvider.tsx
@@ -40,6 +40,7 @@ export function FuelProvider({
       ),
     [_uiConfig],
   );
+
   if (ui) {
     return (
       <FuelHooksProvider fuelConfig={fuelConfig} networks={networks}>

--- a/packages/react/src/ui/Connect/components/Network/NetworkDialog.tsx
+++ b/packages/react/src/ui/Connect/components/Network/NetworkDialog.tsx
@@ -46,7 +46,7 @@ export function NetworkDialog({
       }
       return '';
     },
-    initialData: '',
+    placeholderData: '',
   });
 
   function handleSwitch() {

--- a/packages/react/src/ui/Connect/components/Network/NetworkDialog.tsx
+++ b/packages/react/src/ui/Connect/components/Network/NetworkDialog.tsx
@@ -1,11 +1,9 @@
-import { CHAIN_IDS, Provider } from 'fuels';
-import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Provider } from 'fuels';
 import {
-  useChain,
   useCurrentConnector,
   useDisconnect,
   useIsConnected,
-  useNodeInfo,
   useSelectNetwork,
 } from '../../../../hooks';
 import { useIsSupportedNetwork } from '../../../../hooks/useIsSupportedNetwork';
@@ -39,7 +37,17 @@ export function NetworkDialog({
   const { isSupportedNetwork } = useIsSupportedNetwork();
   const { selectNetwork, isError, error, isPending } = useSelectNetwork();
   const { isConnected } = useIsConnected();
-  const [chainName, setChainName] = useState('');
+  const { data: chainName } = useQuery({
+    queryKey: ['chainName', networks[0]],
+    queryFn: async () => {
+      if (networks[0].url) {
+        const provider = await Provider.create(networks[0].url);
+        return provider.getChain().name;
+      }
+      return '';
+    },
+    initialData: '',
+  });
 
   function handleSwitch() {
     if (networks[0].chainId == null) return;
@@ -68,12 +76,6 @@ export function NetworkDialog({
     return null;
   }
 
-  if (networks[0].url) {
-    Provider.create(networks[0].url).then((provider) => {
-      const chainName = provider.getChain().name;
-      setChainName(chainName);
-    });
-  }
   return (
     <DialogFuel open={!isSupportedNetwork && !!chainName} theme={theme}>
       <DialogContent

--- a/packages/react/src/utils/queryKeys.ts
+++ b/packages/react/src/utils/queryKeys.ts
@@ -1,11 +1,5 @@
 import type { QueryKey } from '@tanstack/react-query';
-import type {
-  BytesLike,
-  FuelConnector,
-  Network,
-  Provider,
-  SelectNetworkArguments,
-} from 'fuels';
+import type { BytesLike, Network, Provider } from 'fuels';
 
 export const QUERY_KEYS = {
   base: ['fuel'] as QueryKey,

--- a/packages/react/src/utils/useWindowConnectorEvent.ts
+++ b/packages/react/src/utils/useWindowConnectorEvent.ts
@@ -1,0 +1,31 @@
+import { Fuel, type FuelConnector, FuelConnectorEventType } from 'fuels';
+import { useEffect } from 'react';
+
+export function useWindowConnectorEvent(fuel: Fuel) {
+  // https://github.com/FuelLabs/fuels-ts/commit/3b59f1fba06d4d2e4884c03bb5e77388394f2b32
+  // On this PR the event listeners was delayed for after a ping what can cause issues with
+  // the Wallet that is not connected.
+  //
+  // The solution for the problem would be to listen to the event and do check inside the handler
+  // if the connector on the event is the current connector so select it.
+  //
+  // TODO: move this to the Fuel TS SDK
+  useEffect(() => {
+    const handler = (connector: CustomEvent<FuelConnector>) => {
+      const currentFuelConnector = fuel.currentConnector();
+      const currentConnector = localStorage.getItem(Fuel.STORAGE_KEY);
+      if (currentConnector === connector.detail.name && !currentFuelConnector) {
+        fuel.selectConnector(connector.detail.name, {
+          emitEvents: false,
+        });
+      }
+    };
+
+    // biome-ignore lint/suspicious/noExplicitAny: This is a listener is not defined on window
+    window.addEventListener(FuelConnectorEventType, handler as any);
+    return () => {
+      // biome-ignore lint/suspicious/noExplicitAny: This is a listener is not defined on window
+      window.removeEventListener(FuelConnectorEventType, handler as any);
+    };
+  }, [fuel]);
+}


### PR DESCRIPTION
On this PR https://github.com/FuelLabs/fuels-ts/commit/3b59f1fba06d4d2e4884c03bb5e77388394f2b32

The event listeners for global target on delayed to avoid race condition as this would set the first connector to respond tu this event as current connector.

This assumption was correct, but we should change to first listen the global target events, and than check inside handler If the event received is the current connector on the storage if yes it should use it, and call selectConnector.

This PR creates a hook `useWindowConnectorEvent` that execute this behavior.