### PR TITLE
feat: add sign message custom curves

### DIFF
--- a/.changeset/lazy-apples-beg.md
+++ b/.changeset/lazy-apples-beg.md
@@ -1,0 +1,9 @@
+---
+"@fuel-connectors/walletconnect-connector": patch
+"@fuel-connectors/solana-connector": patch
+"@fuel-connectors/evm-connector": patch
+"@fuels/connectors": patch
+"@fuel-connectors/common": patch
+---
+
+feat: add sign message with custom curves for predicates

--- a/packages/common/src/PredicateConnector.ts
+++ b/packages/common/src/PredicateConnector.ts
@@ -28,6 +28,7 @@ import type {
   PredicateVersion,
   PreparedTransaction,
   ProviderDictionary,
+  SignedMessageCustomCurve,
 } from './types';
 
 export abstract class PredicateConnector extends FuelConnector {
@@ -60,6 +61,9 @@ export abstract class PredicateConnector extends FuelConnector {
   protected abstract getProviders(): Promise<ProviderDictionary>;
   protected abstract requireConnection(): MaybeAsync<void>;
   protected abstract walletAccounts(): Promise<Array<string>>;
+  abstract signMessageCustomCurve(
+    _message: string,
+  ): Promise<SignedMessageCustomCurve>;
 
   protected async emitAccountChange(
     address: string,

--- a/packages/common/src/test/testConnector.ts
+++ b/packages/common/src/test/testConnector.ts
@@ -8,6 +8,7 @@ import {
   type PredicateVersion,
   type PredicateWalletAdapter,
   type ProviderDictionary,
+  type SignedMessageCustomCurve,
   SolanaWalletAdapter,
 } from '../index';
 import versions from './mockedPredicate';
@@ -61,6 +62,12 @@ export class TestPredicatedConnector extends PredicateConnector {
   }
 
   public disconnect(): Promise<boolean> {
+    throw new Error('Method not implemented.');
+  }
+
+  public signMessageCustomCurve(
+    _message: string,
+  ): Promise<SignedMessageCustomCurve> {
     throw new Error('Method not implemented.');
   }
 }

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -48,3 +48,8 @@ export type PreparedTransaction = {
   account: string;
   transactionRequest: TransactionRequest;
 };
+
+export type SignedMessageCustomCurve = {
+  curve: string;
+  signature: string;
+};

--- a/packages/connectors/src/createConfig.ts
+++ b/packages/connectors/src/createConfig.ts
@@ -1,4 +1,5 @@
-import type { FuelConfig } from 'fuels';
+import type { PredicateConnector } from '@fuel-connectors/common';
+import type { FuelConfig, FuelConnector } from 'fuels';
 
 export function createConfig(func: () => FuelConfig) {
   if (typeof window === 'undefined')
@@ -6,4 +7,11 @@ export function createConfig(func: () => FuelConfig) {
       connectors: [],
     };
   return func();
+}
+
+export function hasSignMessageCustomCurve(
+  connector?: FuelConnector | PredicateConnector | null,
+): connector is PredicateConnector {
+  if (!connector) return false;
+  return (connector as PredicateConnector).signMessageCustomCurve !== undefined;
 }

--- a/packages/evm-connector/src/EvmWalletConnector.ts
+++ b/packages/evm-connector/src/EvmWalletConnector.ts
@@ -258,4 +258,19 @@ export class EVMWalletConnector extends PredicateConnector {
 
     return response.submit.id;
   }
+
+  async signMessageCustomCurve(message: string) {
+    const { ethProvider } = await this.getProviders();
+    if (!ethProvider) throw new Error('Eth provider not found');
+    const accountAddress = await this.getAccountAddress();
+    if (!accountAddress) throw new Error('No connected accounts');
+    const signature = await ethProvider.request({
+      method: 'personal_sign',
+      params: [accountAddress, message],
+    });
+    return {
+      curve: 'secp256k1',
+      signature: signature as string,
+    };
+  }
 }

--- a/packages/solana-connector/src/SolanaConnector.ts
+++ b/packages/solana-connector/src/SolanaConnector.ts
@@ -18,6 +18,8 @@ import {
   FuelConnectorEventTypes,
   Provider as FuelProvider,
   type TransactionRequestLike,
+  hexlify,
+  toUtf8Bytes,
 } from 'fuels';
 import { HAS_WINDOW, SOLANA_ICON } from './constants';
 import { PREDICATE_VERSIONS } from './generated/predicates';
@@ -263,5 +265,20 @@ export class SolanaConnector extends PredicateConnector {
     const response = await predicate.sendTransaction(transactionRequest);
 
     return response.id;
+  }
+
+  async signMessageCustomCurve(message: string) {
+    const provider: Maybe<SolanaProvider> =
+      this.web3Modal.getWalletProvider() as SolanaProvider;
+    if (!provider) {
+      throw new Error('No provider found');
+    }
+    const signedMessage: Uint8Array = (await provider.signMessage(
+      toUtf8Bytes(message),
+    )) as Uint8Array;
+    return {
+      curve: 'edDSA',
+      signature: hexlify(signedMessage),
+    };
   }
 }

--- a/packages/walletconnect-connector/src/WalletConnectConnector.ts
+++ b/packages/walletconnect-connector/src/WalletConnectConnector.ts
@@ -452,4 +452,19 @@ export class WalletConnectConnector extends PredicateConnector {
       throw error;
     }
   }
+
+  async signMessageCustomCurve(message: string) {
+    const { ethProvider } = await this.getProviders();
+    if (!ethProvider) throw new Error('Eth provider not found');
+    const accountAddress = await this.getAccountAddress();
+    if (!accountAddress) throw new Error('No connected accounts');
+    const signature = await ethProvider.request({
+      method: 'personal_sign',
+      params: [accountAddress, message],
+    });
+    return {
+      curve: 'secp256k1',
+      signature: signature as string,
+    };
+  }
 }


### PR DESCRIPTION
This PR adds a signMessageCustomCurve that, if it exists, can be used to sign messages using the underlying connector application. This signature can return any type of signature; because of this, the object returned includes the `curve` and `signature`.

```ts
const { wallet } = useWallet();
const { currentConnector } = useCurrentConnector();

if (hasSignMessageCustomCurve(currentConnector)) {
  const { curve, signature } =
    await currentConnector.signMessageCustomCurve(message);

  setSignature(`${curve} signature - ${signature}`);
} else if (wallet) {
  const signature = await wallet.signMessage(message);
  setSignature(`Native signature - ${signature}`);
}
```