### PR TITLE
fix: enforce bech32 for backward compatibility

### DIFF
--- a/.changeset/thick-falcons-kneel.md
+++ b/.changeset/thick-falcons-kneel.md
@@ -1,0 +1,5 @@
+---
+"@fuel-connectors/fuel-wallet": patch
+---
+
+fix: enforce bech32 to fuel wallet for backwards compatibility

--- a/packages/fuel-wallet/src/FuelWalletConnector.ts
+++ b/packages/fuel-wallet/src/FuelWalletConnector.ts
@@ -184,7 +184,8 @@ export class FuelWalletConnector extends FuelConnector {
       throw new Error('Message is required');
     }
     return this.client.request('signMessage', {
-      address,
+      // TODO: update wallets to support b256 addresses instead for using bech32address
+      address: Address.fromString(address).bech32Address,
       message,
     });
   }
@@ -209,7 +210,8 @@ export class FuelWalletConnector extends FuelConnector {
     };
 
     return this.client.request('sendTransaction', {
-      address,
+      // TODO: update wallets to support b256 addresses instead for using bech32address
+      address: Address.fromString(address).bech32Address,
       transaction: JSON.stringify(txRequest),
       provider,
     });

--- a/packages/react/src/icons/CopyIcon.tsx
+++ b/packages/react/src/icons/CopyIcon.tsx
@@ -9,9 +9,9 @@ export function CopyIcon({ size, ...props }: SvgIconProps) {
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
-      stroke-width="2"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
       {...props}
     >
       <title>Copy Icon</title>

--- a/packages/react/src/icons/InfoCircleIcon.tsx
+++ b/packages/react/src/icons/InfoCircleIcon.tsx
@@ -16,13 +16,13 @@ export function InfoCircleIcon({
       {...props}
     >
       <title>Info Circle Icon</title>
-      <g clip-path="url(#clip0_2341_25997)">
+      <g clipPath="url(#clip0_2341_25997)">
         <path
           d="M5.375 5.5H6L6 8.125M10.625 6C10.625 8.55432 8.55432 10.625 6 10.625C3.44568 10.625 1.375 8.55432 1.375 6C1.375 3.44568 3.44568 1.375 6 1.375C8.55432 1.375 10.625 3.44568 10.625 6Z"
           stroke={stroke}
-          stroke-width="1.5"
-          stroke-linecap="round"
-          stroke-linejoin="round"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
         />
         <rect
           x="5.625"
@@ -32,7 +32,7 @@ export function InfoCircleIcon({
           rx="0.375"
           fill={stroke}
           stroke={stroke}
-          stroke-width="0.25"
+          strokeWidth="0.25"
         />
       </g>
       <defs>


### PR DESCRIPTION
This enforces messages to be sent to bech32 addresses inside the Fuel Wallet.