### PR TITLE
fix: hooks with outdated data or stuck in loading

### DIFF
--- a/.changeset/nine-chefs-thank.md
+++ b/.changeset/nine-chefs-thank.md
@@ -1,0 +1,6 @@
+---
+"@fuels/react": patch
+"docs": patch
+---
+
+Fixed hooks with outdated data or stuck in loading

--- a/packages/docs/.typedoc/hooks-links.json
+++ b/packages/docs/.typedoc/hooks-links.json
@@ -19,21 +19,13 @@
     "link": "/guide/react-hooks/useAddNetwork",
     "items": []
   },
-  {
-    "text": "useAssets",
-    "link": "/guide/react-hooks/useAssets",
-    "items": []
-  },
+  { "text": "useAssets", "link": "/guide/react-hooks/useAssets", "items": [] },
   {
     "text": "useBalance",
     "link": "/guide/react-hooks/useBalance",
     "items": []
   },
-  {
-    "text": "useChain",
-    "link": "/guide/react-hooks/useChain",
-    "items": []
-  },
+  { "text": "useChain", "link": "/guide/react-hooks/useChain", "items": [] },
   {
     "text": "useConnect",
     "link": "/guide/react-hooks/useConnect",
@@ -114,9 +106,5 @@
     "link": "/guide/react-hooks/useTransactionResult",
     "items": []
   },
-  {
-    "text": "useWallet",
-    "link": "/guide/react-hooks/useWallet",
-    "items": []
-  }
+  { "text": "useWallet", "link": "/guide/react-hooks/useWallet", "items": [] }
 ]

--- a/packages/docs/.typedoc/hooks-links.json
+++ b/packages/docs/.typedoc/hooks-links.json
@@ -19,13 +19,21 @@
     "link": "/guide/react-hooks/useAddNetwork",
     "items": []
   },
-  { "text": "useAssets", "link": "/guide/react-hooks/useAssets", "items": [] },
+  {
+    "text": "useAssets",
+    "link": "/guide/react-hooks/useAssets",
+    "items": []
+  },
   {
     "text": "useBalance",
     "link": "/guide/react-hooks/useBalance",
     "items": []
   },
-  { "text": "useChain", "link": "/guide/react-hooks/useChain", "items": [] },
+  {
+    "text": "useChain",
+    "link": "/guide/react-hooks/useChain",
+    "items": []
+  },
   {
     "text": "useConnect",
     "link": "/guide/react-hooks/useConnect",
@@ -106,5 +114,9 @@
     "link": "/guide/react-hooks/useTransactionResult",
     "items": []
   },
-  { "text": "useWallet", "link": "/guide/react-hooks/useWallet", "items": [] }
+  {
+    "text": "useWallet",
+    "link": "/guide/react-hooks/useWallet",
+    "items": []
+  }
 ]

--- a/packages/docs/src/guide/react-hooks/useAccount.md
+++ b/packages/docs/src/guide/react-hooks/useAccount.md
@@ -17,6 +17,6 @@ console.log(account);
 ```
 
 #### Defined in
-[packages/react/src/hooks/useAccount.ts:26](https://github.com/fuellabs/fuel-connectors/blob/main/packages/react/src/hooks/useAccount.ts#L26)
+[packages/react/src/hooks/useAccount.ts:29](https://github.com/fuellabs/fuel-connectors/blob/main/packages/react/src/hooks/useAccount.ts#L29)
 
 ___

--- a/packages/docs/src/guide/react-hooks/useChain.md
+++ b/packages/docs/src/guide/react-hooks/useChain.md
@@ -17,6 +17,6 @@ console.log(chain);
 ```
 
 #### Defined in
-[packages/react/src/hooks/useChain.ts:32](https://github.com/fuellabs/fuel-connectors/blob/main/packages/react/src/hooks/useChain.ts#L32)
+[packages/react/src/hooks/useChain.ts:22](https://github.com/fuellabs/fuel-connectors/blob/main/packages/react/src/hooks/useChain.ts#L22)
 
 ___

--- a/packages/docs/src/guide/react-hooks/useCurrentConnector.md
+++ b/packages/docs/src/guide/react-hooks/useCurrentConnector.md
@@ -23,6 +23,6 @@ console.log(currentConnector);
 ```
 
 #### Defined in
-[packages/react/src/hooks/useCurrentConnector.tsx:31](https://github.com/fuellabs/fuel-connectors/blob/main/packages/react/src/hooks/useCurrentConnector.tsx#L31)
+[packages/react/src/hooks/useCurrentConnector.tsx:36](https://github.com/fuellabs/fuel-connectors/blob/main/packages/react/src/hooks/useCurrentConnector.tsx#L36)
 
 ___

--- a/packages/docs/src/guide/react-hooks/useIsSupportedNetwork.md
+++ b/packages/docs/src/guide/react-hooks/useIsSupportedNetwork.md
@@ -17,6 +17,6 @@ console.log(isSupportedNetwork);
 ```
 
 #### Defined in
-[packages/react/src/hooks/useIsSupportedNetwork.tsx:29](https://github.com/fuellabs/fuel-connectors/blob/main/packages/react/src/hooks/useIsSupportedNetwork.tsx#L29)
+[packages/react/src/hooks/useIsSupportedNetwork.tsx:30](https://github.com/fuellabs/fuel-connectors/blob/main/packages/react/src/hooks/useIsSupportedNetwork.tsx#L30)
 
 ___

--- a/packages/docs/src/guide/react-hooks/useNetwork.md
+++ b/packages/docs/src/guide/react-hooks/useNetwork.md
@@ -18,6 +18,6 @@ console.log(network);
 ```
 
 #### Defined in
-[packages/react/src/hooks/useNetwork.ts:29](https://github.com/fuellabs/fuel-connectors/blob/main/packages/react/src/hooks/useNetwork.ts#L29)
+[packages/react/src/hooks/useNetwork.ts:36](https://github.com/fuellabs/fuel-connectors/blob/main/packages/react/src/hooks/useNetwork.ts#L36)
 
 ___

--- a/packages/docs/src/guide/react-hooks/useProvider.md
+++ b/packages/docs/src/guide/react-hooks/useProvider.md
@@ -17,6 +17,6 @@ const { provider } = useProvider();
 ```
 
 #### Defined in
-[packages/react/src/hooks/useProvider.ts:35](https://github.com/fuellabs/fuel-connectors/blob/main/packages/react/src/hooks/useProvider.ts#L35)
+[packages/react/src/hooks/useProvider.ts:37](https://github.com/fuellabs/fuel-connectors/blob/main/packages/react/src/hooks/useProvider.ts#L37)
 
 ___

--- a/packages/docs/src/guide/react-hooks/useProvider.md
+++ b/packages/docs/src/guide/react-hooks/useProvider.md
@@ -17,6 +17,6 @@ const { provider } = useProvider();
 ```
 
 #### Defined in
-[packages/react/src/hooks/useProvider.ts:32](https://github.com/fuellabs/fuel-connectors/blob/main/packages/react/src/hooks/useProvider.ts#L32)
+[packages/react/src/hooks/useProvider.ts:35](https://github.com/fuellabs/fuel-connectors/blob/main/packages/react/src/hooks/useProvider.ts#L35)
 
 ___

--- a/packages/docs/src/guide/react-hooks/useWallet.md
+++ b/packages/docs/src/guide/react-hooks/useWallet.md
@@ -24,4 +24,4 @@ const { wallet } = useWallet();
 Use `useWallet({ account })` instead.
 
 #### Defined in
-[packages/react/src/hooks/useWallet.ts:53](https://github.com/fuellabs/fuel-connectors/blob/main/packages/react/src/hooks/useWallet.ts#L53)
+[packages/react/src/hooks/useWallet.ts:55](https://github.com/fuellabs/fuel-connectors/blob/main/packages/react/src/hooks/useWallet.ts#L55)

--- a/packages/react/src/core/useNamedQuery.ts
+++ b/packages/react/src/core/useNamedQuery.ts
@@ -65,16 +65,12 @@ function createProxyHandler<
   TName extends string,
   TData = unknown,
   TError = DefaultError,
->(name: TName, incomingIsFetching?: boolean) {
+>(name: TName) {
   const handlers: ProxyHandler<UseQueryResult<TData, TError>> = {
     get(target, prop) {
       const shouldReplaceData = prop === name;
       if (shouldReplaceData) {
         return Reflect.get(target, 'data');
-      }
-
-      if (prop === 'isFetching') {
-        return incomingIsFetching || Reflect.get(target, 'isFetching');
       }
 
       return Reflect.get(target, prop);
@@ -101,16 +97,15 @@ export function useNamedQuery<
   name: TName,
   options: UseNamedQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
   queryClient?: QueryClient,
-  fetchingExternal?: boolean,
 ): DefinedNamedUseQueryResult<TName, TData, TError> {
   const query = useQuery(options, queryClient);
 
   const proxy = useMemo(() => {
     return new Proxy(
       query,
-      createProxyHandler(name, fetchingExternal),
+      createProxyHandler(name),
     ) as DefinedNamedUseQueryResult<TName, TData, TError>;
-  }, [name, query, fetchingExternal]);
+  }, [name, query]);
 
   return proxy;
 }

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -11,6 +11,7 @@ export * from './useConnectors';
 export * from './useDisconnect';
 export * from './useIsConnected';
 export * from './useNetwork';
+export * from './useNetworkProvider';
 export * from './useNetworks';
 export * from './useNodeInfo';
 export * from './useProvider';

--- a/packages/react/src/hooks/useAccount.ts
+++ b/packages/react/src/hooks/useAccount.ts
@@ -1,6 +1,3 @@
-import { keepPreviousData } from '@tanstack/react-query';
-import { FuelConnectorEventTypes } from 'fuels';
-import { useEffect } from 'react';
 import { type UseNamedQueryParams, useNamedQuery } from '../core';
 import { useFuel } from '../providers';
 import { QUERY_KEYS } from '../utils';

--- a/packages/react/src/hooks/useAccount.ts
+++ b/packages/react/src/hooks/useAccount.ts
@@ -31,15 +31,11 @@ export const useAccount = (
   return useNamedQuery('account', {
     queryKey: QUERY_KEYS.account(fuel.name),
     queryFn: async () => {
-      try {
-        const currentFuelAccount = await fuel?.currentAccount();
-        return currentFuelAccount;
-      } catch (_error: unknown) {
-        return null;
-      }
+      return await fuel?.currentAccount();
     },
     placeholderData: null,
     retry: 5,
+    retryDelay: 100,
     ...params?.query,
   });
 };

--- a/packages/react/src/hooks/useAccount.ts
+++ b/packages/react/src/hooks/useAccount.ts
@@ -31,7 +31,7 @@ export const useAccount = (
 ) => {
   const { fuel } = useFuel();
 
-  const accountQuery = useNamedQuery('account', {
+  return useNamedQuery('account', {
     queryKey: QUERY_KEYS.account(fuel.name),
     queryFn: async () => {
       try {
@@ -45,15 +45,4 @@ export const useAccount = (
     retry: 5,
     ...params?.query,
   });
-
-  useEffect(() => {
-    const sub = fuel.on(FuelConnectorEventTypes.currentAccount, () => {
-      accountQuery.refetch();
-    });
-    return () => {
-      sub.unsubscribe();
-    };
-  }, [fuel, accountQuery.refetch]);
-
-  return accountQuery;
 };

--- a/packages/react/src/hooks/useChain.ts
+++ b/packages/react/src/hooks/useChain.ts
@@ -3,7 +3,7 @@
 import type { ChainInfo } from 'fuels';
 
 import { useMemo } from 'react';
-import { useProvider } from './useProvider';
+import { useNetworkProvider } from './useNetworkProvider';
 
 // @TODO: Add a link to fuel connector's documentation.
 /**
@@ -20,8 +20,8 @@ import { useProvider } from './useProvider';
  * ```
  */
 export const useChain = () => {
-  const providerData = useProvider();
-  const provider = providerData?.provider;
+  const providerData = useNetworkProvider();
+  const provider = providerData?.networkProvider;
 
   return useMemo(() => {
     try {

--- a/packages/react/src/hooks/useChain.ts
+++ b/packages/react/src/hooks/useChain.ts
@@ -1,19 +1,9 @@
 // should import ChainInfo because of this error: https://github.com/FuelLabs/fuels-ts/issues/1054
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type { ChainInfo } from 'fuels';
-import type { UseNamedQueryParams } from '../core';
 
-import { useNamedQuery } from '../core';
-import { QUERY_KEYS } from '../utils';
-
+import { useMemo } from 'react';
 import { useProvider } from './useProvider';
-
-type UseChainParams<TName extends string, TData> = {
-  /**
-   * Additional query parameters to customize the behavior of `useNamedQuery`.
-   */
-  query?: UseNamedQueryParams<TName, TData, Error, TData>;
-};
 
 // @TODO: Add a link to fuel connector's documentation.
 /**
@@ -29,23 +19,17 @@ type UseChainParams<TName extends string, TData> = {
  * console.log(chain);
  * ```
  */
-export const useChain = (
-  params?: UseChainParams<'chain', ChainInfo | null>,
-) => {
-  const { provider } = useProvider();
+export const useChain = () => {
+  const providerData = useProvider();
+  const provider = providerData?.provider;
 
-  return useNamedQuery('chain', {
-    queryKey: QUERY_KEYS.chain(),
-    queryFn: async () => {
-      try {
-        const currentFuelChain = await provider?.getChain();
-        return currentFuelChain || null;
-      } catch (_error: unknown) {
-        return null;
-      }
-    },
-    placeholderData: null,
-    enabled: !!provider,
-    ...params?.query,
-  });
+  return useMemo(() => {
+    try {
+      const currentFuelChain = provider?.getChain();
+      return { chain: currentFuelChain || null };
+    } catch (e) {
+      console.error(e);
+      return { provider: null };
+    }
+  }, [provider]);
 };

--- a/packages/react/src/hooks/useCurrentConnector.tsx
+++ b/packages/react/src/hooks/useCurrentConnector.tsx
@@ -40,7 +40,7 @@ export const useCurrentConnector = <
   query,
 }: UseCurrentConnectorParams<TName, TData> = {}) => {
   const { fuel } = useFuel();
-  const connectorQuery = useNamedQuery('currentConnector', {
+  return useNamedQuery('currentConnector', {
     queryKey: QUERY_KEYS.currentConnector(fuel.name),
     queryFn: async () => {
       const isConnected = await fuel.isConnected();
@@ -50,16 +50,4 @@ export const useCurrentConnector = <
     placeholderData: null,
     ...query,
   });
-
-  useEffect(() => {
-    const onChangeConnector = () => {
-      connectorQuery.refetch();
-    };
-    fuel.on(FuelConnectorEventTypes.currentConnector, onChangeConnector);
-    return () => {
-      fuel.off(FuelConnectorEventTypes.currentConnector, onChangeConnector);
-    };
-  }, [connectorQuery.refetch, fuel]);
-
-  return connectorQuery;
 };

--- a/packages/react/src/hooks/useNetwork.ts
+++ b/packages/react/src/hooks/useNetwork.ts
@@ -1,6 +1,4 @@
-import { keepPreviousData } from '@tanstack/react-query';
-import { FuelConnectorEventTypes, type Network } from 'fuels';
-import { useEffect } from 'react';
+import type { Network } from 'fuels';
 import { type UseNamedQueryParams, useNamedQuery } from '../core';
 import { useFuel } from '../providers';
 import { QUERY_KEYS } from '../utils';
@@ -71,6 +69,5 @@ export const useNetwork = (params?: UseNetwork) => {
       ...params?.query,
     },
     undefined,
-    connectedQuery.isFetching,
   );
 };

--- a/packages/react/src/hooks/useNetwork.ts
+++ b/packages/react/src/hooks/useNetwork.ts
@@ -38,7 +38,7 @@ export const useNetwork = (params?: UseNetwork) => {
   const connectedQuery = useIsConnected();
   const isConnected = connectedQuery.isConnected;
 
-  const networkQuery = useNamedQuery(
+  return useNamedQuery(
     'network',
     {
       queryKey: QUERY_KEYS.currentNetwork(isConnected),
@@ -73,15 +73,4 @@ export const useNetwork = (params?: UseNetwork) => {
     undefined,
     connectedQuery.isFetching,
   );
-
-  useEffect(() => {
-    const sub = fuel.on(FuelConnectorEventTypes.currentNetwork, () => {
-      networkQuery.refetch();
-    });
-    return () => {
-      sub.unsubscribe();
-    };
-  }, [fuel, networkQuery.refetch]);
-
-  return networkQuery;
 };

--- a/packages/react/src/hooks/useNetwork.ts
+++ b/packages/react/src/hooks/useNetwork.ts
@@ -35,7 +35,9 @@ type UseNetwork = {
  */
 export const useNetwork = (params?: UseNetwork) => {
   const { fuel } = useFuel();
-  const { isConnected } = useIsConnected();
+  const connectedQuery = useIsConnected();
+  const isConnected = connectedQuery.isConnected;
+
   const networkQuery = useNamedQuery('network', {
     queryKey: QUERY_KEYS.currentNetwork(isConnected),
     queryFn: async () => {

--- a/packages/react/src/hooks/useNetworkProvider.ts
+++ b/packages/react/src/hooks/useNetworkProvider.ts
@@ -4,7 +4,7 @@ import { type UseNamedQueryParams, useNamedQuery } from '../core';
 import { QUERY_KEYS } from '../utils';
 import { useNetwork } from './useNetwork';
 
-type UseProviderParams = {
+type UseNetworkProviderParams = {
   networkUrl?: string;
   chainId?: number;
   /**
@@ -32,7 +32,7 @@ type UseProviderParams = {
  * const { networkProvider } = useNetworkProvider();
  * ```
  */
-export const useNetworkProvider = (params?: UseProviderParams) => {
+export const useNetworkProvider = (params?: UseNetworkProviderParams) => {
   const networkQuery = useNetwork();
   const currentNetwork = networkQuery.network;
   const networkUrl = params?.networkUrl || currentNetwork?.url;

--- a/packages/react/src/hooks/useNetworkProvider.ts
+++ b/packages/react/src/hooks/useNetworkProvider.ts
@@ -11,7 +11,7 @@ type UseProviderParams = {
    * Additional query parameters to customize the behavior of `useNamedQuery`.
    */
   query?: UseNamedQueryParams<
-    'provider',
+    'networkProvider',
     Provider | null,
     Error,
     Provider | null
@@ -32,14 +32,14 @@ type UseProviderParams = {
  * const { provider } = useProvider();
  * ```
  */
-export const useProvider = (params?: UseProviderParams) => {
+export const useNetworkProvider = (params?: UseProviderParams) => {
   const networkQuery = useNetwork();
   const currentNetwork = networkQuery.network;
   const networkUrl = params?.networkUrl || currentNetwork?.url;
   const chainId = params?.chainId || currentNetwork?.chainId;
 
   return useNamedQuery(
-    'provider',
+    'networkProvider',
     {
       queryKey: QUERY_KEYS.networkProvider(networkUrl, chainId),
       queryFn: async () => {

--- a/packages/react/src/hooks/useNetworkProvider.ts
+++ b/packages/react/src/hooks/useNetworkProvider.ts
@@ -29,7 +29,7 @@ type UseProviderParams = {
  * @examples
  * To get the current provider:
  * ```ts
- * const { provider } = useProvider();
+ * const { networkProvider } = useNetworkProvider();
  * ```
  */
 export const useNetworkProvider = (params?: UseProviderParams) => {

--- a/packages/react/src/hooks/useNetworkProvider.ts
+++ b/packages/react/src/hooks/useNetworkProvider.ts
@@ -80,6 +80,5 @@ export const useNetworkProvider = (params?: UseProviderParams) => {
       ...params?.query,
     },
     undefined,
-    networkQuery.isFetching,
   );
 };

--- a/packages/react/src/hooks/useNetworkProvider.ts
+++ b/packages/react/src/hooks/useNetworkProvider.ts
@@ -1,0 +1,99 @@
+import { keepPreviousData } from '@tanstack/react-query';
+import { Provider } from 'fuels';
+import { type UseNamedQueryParams, useNamedQuery } from '../core';
+import { useFuel } from '../providers';
+import { QUERY_KEYS } from '../utils';
+import { useNetwork } from './useNetwork';
+import { useWallet } from './useWallet';
+
+type UseProviderParams = {
+  networkUrl?: string;
+  chainId?: number;
+  /**
+   * Additional query parameters to customize the behavior of `useNamedQuery`.
+   */
+  query?: UseNamedQueryParams<
+    'provider',
+    Provider | null,
+    Error,
+    Provider | null
+  >;
+};
+
+// @TODO: Add a link to fuel connector's documentation.
+/**
+ * A hook to retrieve the current provider in the connected app.
+ *
+ * @returns {object} An object containing:
+ * - `provider`: The provider data or `null`.
+ * - {@link https://tanstack.com/query/latest/docs/framework/react/reference/useQuery | `...queryProps`}: Destructured properties from `useQuery` result.
+ *
+ * @examples
+ * To get the current provider:
+ * ```ts
+ * const { provider } = useProvider();
+ * ```
+ */
+export const useProvider = (params?: UseProviderParams) => {
+  const { fuel } = useFuel();
+  const networkQuery = useNetwork();
+  const walletQuery = useWallet();
+  const currentNetwork = networkQuery.network;
+  const networkUrl = params?.networkUrl || currentNetwork?.url;
+  const chainId = params?.chainId || currentNetwork?.chainId;
+
+  return useNamedQuery(
+    'provider',
+    {
+      queryKey: QUERY_KEYS.provider(
+        walletQuery.wallet?.address.toString(),
+        networkUrl,
+        chainId,
+      ),
+      queryFn: async () => {
+        async function fetchProvider() {
+          if (!networkUrl) {
+            console.warn(
+              'Please provide a networks with a RPC url configuration to your FuelProvider getProvider will be removed.',
+            );
+          }
+          if (walletQuery.wallet) {
+            return walletQuery.wallet.provider || null;
+          }
+          if (!networkUrl) {
+            return fuel.getProvider();
+          }
+          const provider = await Provider.create(networkUrl);
+          if (chainId && provider.getChainId() !== chainId) {
+            throw new Error(
+              `The provider's chainId (${provider.getChainId()}) does not match the current network's chainId (${chainId})`,
+            );
+          }
+          return provider;
+        }
+
+        const timeout = new Promise((_, reject) =>
+          setTimeout(() => reject('Time out fetching provider'), 1000),
+        ) as Promise<Provider | null>;
+
+        return Promise.race([fetchProvider(), timeout]);
+      },
+      placeholderData: keepPreviousData,
+      refetchInterval: (e) => {
+        if (!e.state.data || e.state.error) {
+          return 500;
+        }
+        return false;
+      },
+      retry: (attempts) => {
+        if (attempts > 10) {
+          return false;
+        }
+        return true;
+      },
+      ...params?.query,
+    },
+    undefined,
+    walletQuery.isFetching || networkQuery.isFetching,
+  );
+};

--- a/packages/react/src/hooks/useNodeInfo.ts
+++ b/packages/react/src/hooks/useNodeInfo.ts
@@ -4,7 +4,7 @@ import { type UseNamedQueryParams, useNamedQuery } from '../core';
 import { QUERY_KEYS } from '../utils';
 
 import type { NodeInfo } from 'fuels';
-import { useProvider } from './useProvider';
+import { useNetworkProvider } from './useNetworkProvider';
 
 type UseNodeInfoParams = {
   /**
@@ -45,8 +45,8 @@ export const useNodeInfo = ({
   version = '0.0.0',
   query: queryParams,
 }: UseNodeInfoParams = {}) => {
-  const { provider } = useProvider();
-
+  const networkProviderQuery = useNetworkProvider();
+  const provider = networkProviderQuery.networkProvider;
   const query = useNamedQuery('nodeInfo', {
     queryKey: QUERY_KEYS.nodeInfo(provider?.url),
     queryFn: () => {

--- a/packages/react/src/hooks/useProvider.ts
+++ b/packages/react/src/hooks/useProvider.ts
@@ -34,8 +34,9 @@ type UseProviderParams = {
  */
 export const useProvider = (params?: UseProviderParams) => {
   const { fuel } = useFuel();
-  const { network: currentNetwork } = useNetwork();
+  const networkQuery = useNetwork();
   const { account } = useAccount();
+  const currentNetwork = networkQuery.network;
 
   return useNamedQuery('provider', {
     queryKey: QUERY_KEYS.provider(account, currentNetwork),

--- a/packages/react/src/hooks/useProvider.ts
+++ b/packages/react/src/hooks/useProvider.ts
@@ -1,9 +1,9 @@
 import { keepPreviousData } from '@tanstack/react-query';
 import { Provider } from 'fuels';
-import { useAccount } from 'src/hooks/useAccount';
 import { type UseNamedQueryParams, useNamedQuery } from '../core';
 import { useFuel } from '../providers';
 import { QUERY_KEYS } from '../utils';
+import { useAccount } from './useAccount';
 import { useNetwork } from './useNetwork';
 
 type UseProviderParams = {

--- a/packages/react/src/hooks/useProvider.ts
+++ b/packages/react/src/hooks/useProvider.ts
@@ -1,23 +1,13 @@
-import { keepPreviousData } from '@tanstack/react-query';
-import { Provider } from 'fuels';
+import type { Account } from 'fuels';
 import { type UseNamedQueryParams, useNamedQuery } from '../core';
-import { useFuel } from '../providers';
-import { QUERY_KEYS } from '../utils';
-import { useNetwork } from './useNetwork';
 import { useWallet } from './useWallet';
 
 type UseProviderParams = {
-  networkUrl?: string;
-  chainId?: number;
   /**
-   * Additional query parameters to customize the behavior of `useNamedQuery`.
+   * The wallet address used to fetch the provider. If not provided, the current account's address will be used.
    */
-  query?: UseNamedQueryParams<
-    'provider',
-    Provider | null,
-    Error,
-    Provider | null
-  >;
+  account?: string | null;
+  query?: UseNamedQueryParams<'wallet', Account | null, Error, Account | null>;
 };
 
 // @TODO: Add a link to fuel connector's documentation.
@@ -35,65 +25,6 @@ type UseProviderParams = {
  * ```
  */
 export const useProvider = (params?: UseProviderParams) => {
-  const { fuel } = useFuel();
-  const networkQuery = useNetwork();
-  const walletQuery = useWallet();
-  const currentNetwork = networkQuery.network;
-  const networkUrl = params?.networkUrl || currentNetwork?.url;
-  const chainId = params?.chainId || currentNetwork?.chainId;
-
-  return useNamedQuery(
-    'provider',
-    {
-      queryKey: QUERY_KEYS.provider(
-        walletQuery.wallet?.address.toString(),
-        networkUrl,
-        chainId,
-      ),
-      queryFn: async () => {
-        async function fetchProvider() {
-          if (!networkUrl) {
-            console.warn(
-              'Please provide a networks with a RPC url configuration to your FuelProvider getProvider will be removed.',
-            );
-          }
-          if (walletQuery.wallet) {
-            return walletQuery.wallet.provider || null;
-          }
-          if (!networkUrl) {
-            return fuel.getProvider();
-          }
-          const provider = await Provider.create(networkUrl);
-          if (chainId && provider.getChainId() !== chainId) {
-            throw new Error(
-              `The provider's chainId (${provider.getChainId()}) does not match the current network's chainId (${chainId})`,
-            );
-          }
-          return provider;
-        }
-
-        const timeout = new Promise((_, reject) =>
-          setTimeout(() => reject('Time out fetching provider'), 1000),
-        ) as Promise<Provider | null>;
-
-        return Promise.race([fetchProvider(), timeout]);
-      },
-      placeholderData: keepPreviousData,
-      refetchInterval: (e) => {
-        if (!e.state.data || e.state.error) {
-          return 500;
-        }
-        return false;
-      },
-      retry: (attempts) => {
-        if (attempts > 10) {
-          return false;
-        }
-        return true;
-      },
-      ...params?.query,
-    },
-    undefined,
-    walletQuery.isFetching || networkQuery.isFetching,
-  );
+  const walletQuery = useWallet(params);
+  return walletQuery?.wallet;
 };

--- a/packages/react/src/hooks/useProvider.ts
+++ b/packages/react/src/hooks/useProvider.ts
@@ -1,10 +1,10 @@
 import { keepPreviousData } from '@tanstack/react-query';
 import { Provider } from 'fuels';
-import { useWallet } from 'src/hooks/useWallet';
 import { type UseNamedQueryParams, useNamedQuery } from '../core';
 import { useFuel } from '../providers';
 import { QUERY_KEYS } from '../utils';
 import { useNetwork } from './useNetwork';
+import { useWallet } from './useWallet';
 
 type UseProviderParams = {
   networkUrl?: string;

--- a/packages/react/src/hooks/useProvider.ts
+++ b/packages/react/src/hooks/useProvider.ts
@@ -28,7 +28,7 @@ type UseProviderParams = {
 export const useProvider = (params?: UseProviderParams) => {
   const walletQuery = useWallet(params);
   return useMemo(
-    () => ({ provider: walletQuery?.wallet }),
+    () => ({ provider: walletQuery?.wallet?.provider }),
     [walletQuery.wallet],
   );
 };

--- a/packages/react/src/hooks/useProvider.ts
+++ b/packages/react/src/hooks/useProvider.ts
@@ -1,4 +1,5 @@
 import type { Account } from 'fuels';
+import { useMemo } from 'react';
 import { type UseNamedQueryParams, useNamedQuery } from '../core';
 import { useWallet } from './useWallet';
 
@@ -26,5 +27,8 @@ type UseProviderParams = {
  */
 export const useProvider = (params?: UseProviderParams) => {
   const walletQuery = useWallet(params);
-  return walletQuery?.wallet;
+  return useMemo(
+    () => ({ provider: walletQuery?.wallet }),
+    [walletQuery.wallet],
+  );
 };

--- a/packages/react/src/hooks/useProvider.ts
+++ b/packages/react/src/hooks/useProvider.ts
@@ -29,6 +29,6 @@ export const useProvider = (params?: UseProviderParams) => {
   const walletQuery = useWallet(params);
   return useMemo(
     () => ({ provider: walletQuery?.wallet?.provider }),
-    [walletQuery.wallet],
+    [walletQuery.wallet?.provider],
   );
 };

--- a/packages/react/src/hooks/useTransactionReceipts.ts
+++ b/packages/react/src/hooks/useTransactionReceipts.ts
@@ -5,7 +5,7 @@ import type { TransactionResult } from 'fuels';
 
 import { type UseNamedQueryParams, useNamedQuery } from '../core';
 import { QUERY_KEYS } from '../utils';
-import { useProvider } from './useProvider';
+import { useNetworkProvider } from './useNetworkProvider';
 
 type UseTransactionReceiptsParams<TTransactionType = void> = {
   /**
@@ -35,7 +35,8 @@ export const useTransactionReceipts = <TTransactionType = void>({
   txId,
   query,
 }: UseTransactionReceiptsParams<TTransactionType>) => {
-  const { provider } = useProvider();
+  const networkQuery = useNetworkProvider();
+  const provider = networkQuery.networkProvider;
 
   return useNamedQuery('transactionReceipts', {
     queryKey: QUERY_KEYS.transactionReceipts(txId, provider),

--- a/packages/react/src/hooks/useTransactionResult.ts
+++ b/packages/react/src/hooks/useTransactionResult.ts
@@ -5,9 +5,8 @@ import {
 } from 'fuels';
 
 import { type UseNamedQueryParams, useNamedQuery } from '../core';
-import { useFuel } from '../providers';
 import { QUERY_KEYS } from '../utils';
-import { useProvider } from './useProvider';
+import { useNetworkProvider } from './useNetworkProvider';
 
 type UseTransactionResultParams<
   TTransactionType extends TransactionType,
@@ -58,7 +57,8 @@ export const useTransactionResult = <
   txId = '',
   query = {},
 }: UseTransactionResultParams<TTransactionType, TName, TData>) => {
-  const { provider } = useProvider();
+  const networkProviderQuery = useNetworkProvider();
+  const provider = networkProviderQuery.networkProvider;
   const { name = 'transactionResult', ...options } = query;
 
   return useNamedQuery(name, {

--- a/packages/react/src/hooks/useWallet.ts
+++ b/packages/react/src/hooks/useWallet.ts
@@ -1,6 +1,7 @@
-import { type Account, Address } from 'fuels';
+import { type Account, Address, FuelConnectorEventTypes } from 'fuels';
 
 import { keepPreviousData } from '@tanstack/react-query';
+import { useEffect } from 'react';
 import {
   type DefinedNamedUseQueryResult,
   type UseNamedQueryParams,
@@ -68,7 +69,7 @@ export function useWallet(
   const account = _params.account || accountData?.account;
 
   return useNamedQuery('wallet', {
-    queryKey: QUERY_KEYS.wallet(account, provider),
+    queryKey: QUERY_KEYS.wallet(account, fuel.name, provider),
     queryFn: async () => {
       try {
         if (!provider || !account) return null;

--- a/packages/react/src/hooks/useWallet.ts
+++ b/packages/react/src/hooks/useWallet.ts
@@ -1,7 +1,6 @@
 import { type Account, Address } from 'fuels';
 
 import { keepPreviousData } from '@tanstack/react-query';
-import { useAccount } from 'src/hooks/useAccount';
 import {
   type DefinedNamedUseQueryResult,
   type UseNamedQueryParams,
@@ -9,6 +8,7 @@ import {
 } from '../core';
 import { useFuel } from '../providers';
 import { QUERY_KEYS } from '../utils';
+import { useAccount } from './useAccount';
 import { useProvider } from './useProvider';
 
 type UseWalletParamsDeprecated = string | null;

--- a/packages/react/src/providers/FuelEventsWatcher.tsx
+++ b/packages/react/src/providers/FuelEventsWatcher.tsx
@@ -10,14 +10,18 @@ export function FuelEventsWatcher() {
   const queryClient = useQueryClient();
 
   function onCurrentConnectorChange() {
-    queryClient.invalidateQueries({ queryKey: QUERY_KEYS.account() });
+    queryClient.invalidateQueries({ queryKey: QUERY_KEYS.account(undefined) });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.isConnected() });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.wallet() });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.balance() });
-    queryClient.invalidateQueries({ queryKey: QUERY_KEYS.provider() });
+    queryClient.invalidateQueries({
+      queryKey: QUERY_KEYS.provider(null, null),
+    });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.nodeInfo() });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.accounts() });
-    queryClient.invalidateQueries({ queryKey: QUERY_KEYS.currentConnector() });
+    queryClient.invalidateQueries({
+      queryKey: QUERY_KEYS.currentConnector(undefined),
+    });
   }
 
   async function onConnectorsChange() {
@@ -25,22 +29,28 @@ export function FuelEventsWatcher() {
       queryKey: QUERY_KEYS.connectorList(),
       exact: true,
     });
-    queryClient.invalidateQueries({ queryKey: QUERY_KEYS.currentConnector() });
+    queryClient.invalidateQueries({
+      queryKey: QUERY_KEYS.currentConnector(undefined),
+    });
   }
 
   function onCurrentAccountChange() {
-    queryClient.invalidateQueries({ queryKey: QUERY_KEYS.account() });
+    queryClient.invalidateQueries({ queryKey: QUERY_KEYS.account(undefined) });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.wallet() });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.balance() });
   }
 
   function onConnectionChange() {
-    queryClient.invalidateQueries({ queryKey: QUERY_KEYS.currentConnector() });
+    queryClient.invalidateQueries({
+      queryKey: QUERY_KEYS.currentConnector(undefined),
+    });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.isConnected() });
-    queryClient.invalidateQueries({ queryKey: QUERY_KEYS.account() });
+    queryClient.invalidateQueries({ queryKey: QUERY_KEYS.account(undefined) });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.wallet() });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.balance() });
-    queryClient.invalidateQueries({ queryKey: QUERY_KEYS.provider() });
+    queryClient.invalidateQueries({
+      queryKey: QUERY_KEYS.provider(null, null),
+    });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.nodeInfo() });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.accounts() });
     queryClient.resetQueries({
@@ -50,9 +60,13 @@ export function FuelEventsWatcher() {
   }
 
   function onNetworkChange() {
-    queryClient.invalidateQueries({ queryKey: QUERY_KEYS.currentNetwork() });
+    queryClient.invalidateQueries({
+      queryKey: QUERY_KEYS.currentNetwork(undefined),
+    });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.networks() });
-    queryClient.invalidateQueries({ queryKey: QUERY_KEYS.provider() });
+    queryClient.invalidateQueries({
+      queryKey: QUERY_KEYS.provider(null, null),
+    });
     queryClient.invalidateQueries({
       queryKey: QUERY_KEYS.transactionReceipts(),
     });
@@ -60,7 +74,7 @@ export function FuelEventsWatcher() {
   }
 
   function onAccountsChange() {
-    queryClient.invalidateQueries({ queryKey: QUERY_KEYS.account() });
+    queryClient.invalidateQueries({ queryKey: QUERY_KEYS.account(undefined) });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.accounts() });
   }
 

--- a/packages/react/src/providers/FuelEventsWatcher.tsx
+++ b/packages/react/src/providers/FuelEventsWatcher.tsx
@@ -15,7 +15,7 @@ export function FuelEventsWatcher() {
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.wallet() });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.balance() });
     queryClient.invalidateQueries({
-      queryKey: QUERY_KEYS.provider(null, null),
+      queryKey: QUERY_KEYS.provider(null, null, null),
     });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.nodeInfo() });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.accounts() });
@@ -49,7 +49,7 @@ export function FuelEventsWatcher() {
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.wallet() });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.balance() });
     queryClient.invalidateQueries({
-      queryKey: QUERY_KEYS.provider(null, null),
+      queryKey: QUERY_KEYS.provider(null, null, null),
     });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.nodeInfo() });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.accounts() });
@@ -65,7 +65,7 @@ export function FuelEventsWatcher() {
     });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.networks() });
     queryClient.invalidateQueries({
-      queryKey: QUERY_KEYS.provider(null, null),
+      queryKey: QUERY_KEYS.provider(null, null, null),
     });
     queryClient.invalidateQueries({
       queryKey: QUERY_KEYS.transactionReceipts(),

--- a/packages/react/src/providers/FuelEventsWatcher.tsx
+++ b/packages/react/src/providers/FuelEventsWatcher.tsx
@@ -15,7 +15,7 @@ export function FuelEventsWatcher() {
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.wallet() });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.balance() });
     queryClient.invalidateQueries({
-      queryKey: QUERY_KEYS.provider(null, null, null),
+      queryKey: QUERY_KEYS.networkProvider(null, null, null),
     });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.nodeInfo() });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.accounts() });
@@ -49,7 +49,7 @@ export function FuelEventsWatcher() {
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.wallet() });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.balance() });
     queryClient.invalidateQueries({
-      queryKey: QUERY_KEYS.provider(null, null, null),
+      queryKey: QUERY_KEYS.networkProvider(null, null, null),
     });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.nodeInfo() });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.accounts() });
@@ -65,7 +65,7 @@ export function FuelEventsWatcher() {
     });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.networks() });
     queryClient.invalidateQueries({
-      queryKey: QUERY_KEYS.provider(null, null, null),
+      queryKey: QUERY_KEYS.networkProvider(null, null, null),
     });
     queryClient.invalidateQueries({
       queryKey: QUERY_KEYS.transactionReceipts(),

--- a/packages/react/src/providers/FuelEventsWatcher.tsx
+++ b/packages/react/src/providers/FuelEventsWatcher.tsx
@@ -15,7 +15,7 @@ export function FuelEventsWatcher() {
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.wallet() });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.balance() });
     queryClient.invalidateQueries({
-      queryKey: QUERY_KEYS.networkProvider(null, null, null),
+      queryKey: QUERY_KEYS.networkProvider(null, null),
     });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.nodeInfo() });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.accounts() });
@@ -49,7 +49,7 @@ export function FuelEventsWatcher() {
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.wallet() });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.balance() });
     queryClient.invalidateQueries({
-      queryKey: QUERY_KEYS.networkProvider(null, null, null),
+      queryKey: QUERY_KEYS.networkProvider(null, null),
     });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.nodeInfo() });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.accounts() });
@@ -65,7 +65,7 @@ export function FuelEventsWatcher() {
     });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.networks() });
     queryClient.invalidateQueries({
-      queryKey: QUERY_KEYS.networkProvider(null, null, null),
+      queryKey: QUERY_KEYS.networkProvider(null, null),
     });
     queryClient.invalidateQueries({
       queryKey: QUERY_KEYS.transactionReceipts(),

--- a/packages/react/src/providers/FuelEventsWatcher.tsx
+++ b/packages/react/src/providers/FuelEventsWatcher.tsx
@@ -56,7 +56,6 @@ export function FuelEventsWatcher() {
     queryClient.invalidateQueries({
       queryKey: QUERY_KEYS.transactionReceipts(),
     });
-    queryClient.invalidateQueries({ queryKey: QUERY_KEYS.chain() });
     queryClient.invalidateQueries({ queryKey: QUERY_KEYS.nodeInfo() });
   }
 

--- a/packages/react/src/utils/queryKeys.ts
+++ b/packages/react/src/utils/queryKeys.ts
@@ -5,7 +5,9 @@ import type { NetworkConfig } from '../types';
 export const QUERY_KEYS = {
   base: ['fuel'] as QueryKey,
   account: (connectorName: string | null | undefined): QueryKey => {
-    return QUERY_KEYS.base.concat('account', connectorName);
+    const queryKey = QUERY_KEYS.base.concat('account');
+    if (connectorName) queryKey.push(connectorName);
+    return queryKey;
   },
   accounts: (): QueryKey => {
     return QUERY_KEYS.base.concat('accounts');

--- a/packages/react/src/utils/queryKeys.ts
+++ b/packages/react/src/utils/queryKeys.ts
@@ -23,9 +23,6 @@ export const QUERY_KEYS = {
     if (typeof chainId !== 'undefined') queryKey.push(chainId);
     return queryKey;
   },
-  chain: (): QueryKey => {
-    return QUERY_KEYS.base.concat('chain');
-  },
   isConnected: (): QueryKey => {
     return QUERY_KEYS.base.concat('isConnected');
   },

--- a/packages/react/src/utils/queryKeys.ts
+++ b/packages/react/src/utils/queryKeys.ts
@@ -30,7 +30,7 @@ export const QUERY_KEYS = {
     return QUERY_KEYS.base.concat('networks');
   },
   provider: (
-    currentAccount: string | null,
+    currentAccount: string | null | undefined,
     networkUrl: string | undefined | null,
     chainId: number | undefined | null,
   ): QueryKey => {

--- a/packages/react/src/utils/queryKeys.ts
+++ b/packages/react/src/utils/queryKeys.ts
@@ -82,8 +82,8 @@ export const QUERY_KEYS = {
   currentConnector: (): QueryKey => {
     return QUERY_KEYS.base.concat(['currentConnector']);
   },
-  currentNetwork: (): QueryKey => {
-    return QUERY_KEYS.base.concat('currentNetwork');
+  currentNetwork: (isConnected: boolean | undefined): QueryKey => {
+    return QUERY_KEYS.base.concat(['currentNetwork', isConnected]);
   },
   isSupportedNetwork: (
     connectorName: string | null | undefined,

--- a/packages/react/src/utils/queryKeys.ts
+++ b/packages/react/src/utils/queryKeys.ts
@@ -4,8 +4,8 @@ import type { NetworkConfig } from '../types';
 
 export const QUERY_KEYS = {
   base: ['fuel'] as QueryKey,
-  account: (): QueryKey => {
-    return QUERY_KEYS.base.concat('account');
+  account: (connectorName: string | null | undefined): QueryKey => {
+    return QUERY_KEYS.base.concat('account', connectorName);
   },
   accounts: (): QueryKey => {
     return QUERY_KEYS.base.concat('accounts');

--- a/packages/react/src/utils/queryKeys.ts
+++ b/packages/react/src/utils/queryKeys.ts
@@ -52,8 +52,13 @@ export const QUERY_KEYS = {
       queryKey.push(provider.getChainId());
     return queryKey;
   },
-  wallet: (address?: string | null, provider?: Provider | null): QueryKey => {
+  wallet: (
+    address?: string | null,
+    connectorName?: string | null,
+    provider?: Provider | null,
+  ): QueryKey => {
     const queryKey = QUERY_KEYS.base.concat('wallet');
+    if (connectorName) queryKey.push(connectorName);
     if (address) queryKey.push(address);
     if (provider?.getChainId?.() !== undefined)
       queryKey.push(provider.getChainId());

--- a/packages/react/src/utils/queryKeys.ts
+++ b/packages/react/src/utils/queryKeys.ts
@@ -33,12 +33,13 @@ export const QUERY_KEYS = {
     currentAccount: string | null,
     currentNetwork: Network | null,
   ): QueryKey => {
-    return QUERY_KEYS.base.concat(
-      'provider',
-      currentNetwork?.chainId,
-      currentNetwork?.url,
-      currentAccount,
-    );
+    const queryKey = QUERY_KEYS.base.concat('provider');
+    if (currentNetwork) {
+      queryKey.push(currentNetwork.chainId);
+      queryKey.push(currentNetwork.url);
+    }
+    if (currentAccount) queryKey.push(currentAccount);
+    return queryKey;
   },
   balance: (
     address?: string,
@@ -85,10 +86,14 @@ export const QUERY_KEYS = {
     return QUERY_KEYS.base.concat('connectorList');
   },
   currentConnector: (connectorName: string | null | undefined): QueryKey => {
-    return QUERY_KEYS.base.concat(['currentConnector', connectorName]);
+    const queryKey = QUERY_KEYS.base.concat('currentConnector');
+    if (connectorName) queryKey.push(connectorName);
+    return queryKey;
   },
   currentNetwork: (isConnected: boolean | undefined): QueryKey => {
-    return QUERY_KEYS.base.concat(['currentNetwork', isConnected]);
+    const queryKey = QUERY_KEYS.base.concat('currentNetwork');
+    if (isConnected) queryKey.push(isConnected);
+    return queryKey;
   },
   isSupportedNetwork: (
     connectorName: string | null | undefined,

--- a/packages/react/src/utils/queryKeys.ts
+++ b/packages/react/src/utils/queryKeys.ts
@@ -31,13 +31,12 @@ export const QUERY_KEYS = {
   },
   provider: (
     currentAccount: string | null,
-    currentNetwork: Network | null,
+    networkUrl: string | undefined | null,
+    chainId: number | undefined | null,
   ): QueryKey => {
     const queryKey = QUERY_KEYS.base.concat('provider');
-    if (currentNetwork) {
-      queryKey.push(currentNetwork.chainId);
-      queryKey.push(currentNetwork.url);
-    }
+    if (networkUrl) queryKey.push(networkUrl);
+    if (chainId) queryKey.push(chainId);
     if (currentAccount) queryKey.push(currentAccount);
     return queryKey;
   },

--- a/packages/react/src/utils/queryKeys.ts
+++ b/packages/react/src/utils/queryKeys.ts
@@ -32,8 +32,16 @@ export const QUERY_KEYS = {
   networks: (): QueryKey => {
     return QUERY_KEYS.base.concat('networks');
   },
-  provider: (): QueryKey => {
-    return QUERY_KEYS.base.concat('provider');
+  provider: (
+    currentAccount: string | null,
+    currentNetwork: Network | null,
+  ): QueryKey => {
+    return QUERY_KEYS.base.concat(
+      'provider',
+      currentNetwork?.chainId,
+      currentNetwork?.url,
+      currentAccount,
+    );
   },
   balance: (
     address?: string,

--- a/packages/react/src/utils/queryKeys.ts
+++ b/packages/react/src/utils/queryKeys.ts
@@ -55,13 +55,10 @@ export const QUERY_KEYS = {
   wallet: (
     address?: string | null,
     connectorName?: string | null,
-    provider?: Provider | null,
   ): QueryKey => {
     const queryKey = QUERY_KEYS.base.concat('wallet');
     if (connectorName) queryKey.push(connectorName);
     if (address) queryKey.push(address);
-    if (provider?.getChainId?.() !== undefined)
-      queryKey.push(provider.getChainId());
     return queryKey;
   },
   transaction: (id?: string): QueryKey => {

--- a/packages/react/src/utils/queryKeys.ts
+++ b/packages/react/src/utils/queryKeys.ts
@@ -87,8 +87,8 @@ export const QUERY_KEYS = {
   connectorList: (): QueryKey => {
     return QUERY_KEYS.base.concat('connectorList');
   },
-  currentConnector: (): QueryKey => {
-    return QUERY_KEYS.base.concat(['currentConnector']);
+  currentConnector: (connectorName: string | null | undefined): QueryKey => {
+    return QUERY_KEYS.base.concat(['currentConnector', connectorName]);
   },
   currentNetwork: (isConnected: boolean | undefined): QueryKey => {
     return QUERY_KEYS.base.concat(['currentNetwork', isConnected]);

--- a/packages/react/src/utils/queryKeys.ts
+++ b/packages/react/src/utils/queryKeys.ts
@@ -29,15 +29,13 @@ export const QUERY_KEYS = {
   networks: (): QueryKey => {
     return QUERY_KEYS.base.concat('networks');
   },
-  provider: (
-    currentAccount: string | null | undefined,
+  networkProvider: (
     networkUrl: string | undefined | null,
     chainId: number | undefined | null,
   ): QueryKey => {
     const queryKey = QUERY_KEYS.base.concat('provider');
     if (networkUrl) queryKey.push(networkUrl);
     if (chainId) queryKey.push(chainId);
-    if (currentAccount) queryKey.push(currentAccount);
     return queryKey;
   },
   balance: (


### PR DESCRIPTION
- Fixes useProvider not being updated on account/network changes
- Fixes useProvider stuck on `isFetching`
- useWallet, useAccount, useProvider now properly refetches and update when required
- Replaced useChain internally from useQuery to useMemo since the method call is synchronous
- `useProvider` now returns useWallet.provider directly
- New `useNetworkProvider`, which accepts custom network and chainId