### PR TITLE
fix(bako-safe): prevents events from remaining active

### DIFF
--- a/.changeset/tricky-lemons-yell.md
+++ b/.changeset/tricky-lemons-yell.md
@@ -1,0 +1,5 @@
+---
+"@fuel-connectors/bako-safe": patch
+---
+
+fix(bako-safe): prevents events from remaining active

--- a/packages/bako-safe/src/BakoSafeConnector.ts
+++ b/packages/bako-safe/src/BakoSafeConnector.ts
@@ -231,7 +231,6 @@ export class BakoSafeConnector extends FuelConnector {
         // @ts-ignore
         BakoSafeConnectorEvents.TX_CONFIRMED,
         ({ data }: { data: IResponseTxCofirmed }) => {
-          this.dAppWindow?.close();
           resolve(`0x${data.id}`);
         },
       );

--- a/packages/bako-safe/src/constants.ts
+++ b/packages/bako-safe/src/constants.ts
@@ -16,6 +16,8 @@ export const SOCKET_URL = 'https://api.bako.global';
 export const HAS_WINDOW = typeof window !== 'undefined';
 // biome-ignore lint/suspicious/noExplicitAny: <explanation>
 export const WINDOW: any = HAS_WINDOW ? window : {};
-
+export const IS_SAFARI = /^((?!chrome|android).)*safari/i.test(
+  WINDOW.navigator?.userAgent ?? '',
+);
 //storage
 export const SESSION_ID = 'sessionId';


### PR DESCRIPTION
This PR fixes the issue when creating a transaction and receiving the event from a previous transaction.

The problem was that the event emitter was storing the listeners from previous transactions. The `.on` was replaced with `.once` since the events need to be listened to only within the context of each method.

This PR also includes this fix: https://github.com/FuelLabs/fuel-connectors/pull/323