### PR TITLE
feat: Add tests for BurnerWalletConnector FE-411

### DIFF
--- a/e2e-tests/react-app/connectors/BurnerWalletConnector/BurnerWalletConnector.test.ts
+++ b/e2e-tests/react-app/connectors/BurnerWalletConnector/BurnerWalletConnector.test.ts
@@ -1,0 +1,73 @@
+import { getButtonByText, getByAriaLabel, test } from '@fuels/playwright-utils';
+import { type Page, expect } from '@playwright/test';
+
+const connectBurner = async (page: Page, walletName = 'Burner Wallet') => {
+  await page.bringToFront();
+  const connectButton = getButtonByText(page, 'Connect');
+  await connectButton.click();
+  await getByAriaLabel(page, `Connect to ${walletName}`, true).click();
+};
+
+test.describe('BurnerWalletConnector', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.bringToFront();
+  });
+
+  test('should connect and show fuel address', async ({ page }) => {
+    await connectBurner(page);
+
+    expect(await page.waitForSelector('text=Your Fuel Address')).toBeTruthy();
+  });
+
+  test('should connect, disconnect, and reconnect', async ({ page }) => {
+    await connectBurner(page);
+
+    await page.click('text=Disconnect');
+    await page.waitForSelector('text=Connect Wallet');
+
+    await connectBurner(page);
+    expect(await page.waitForSelector('text=Your Fuel Address')).toBeTruthy();
+  });
+
+  test('should connect, refresh and stay connected', async ({ page }) => {
+    await connectBurner(page);
+
+    await page.reload();
+    await page.waitForSelector('text=Your Fuel Address');
+  });
+
+  test('should connect, disconnect, refresh and stay disconnected', async ({
+    page,
+  }) => {
+    await connectBurner(page);
+
+    await page.click('text=Disconnect');
+    await page.waitForSelector('text=Connect Wallet');
+
+    await page.reload();
+    await page.waitForSelector('text=Connect Wallet');
+  });
+
+  // test('should increment counter', async ({ page }) => {
+  //   await connectBurner(page);
+
+  //   await page.click('text=Increment');
+
+  //   expect(await page.waitForSelector('text=Success')).toBeTruthy();
+  //   expect(
+  //     await page.waitForSelector('text=Counter Incremented!'),
+  //   ).toBeTruthy();
+  // });
+
+  // test('should execute transfer', async ({ page }) => {
+  //   await connectBurner(page);
+
+  //   await page.click('text=Transfer 0.0001 ETH');
+
+  //   expect(await page.waitForSelector('text=Success')).toBeTruthy();
+  //   expect(
+  //     await page.waitForSelector('text=Transferred successfully!'),
+  //   ).toBeTruthy();
+  // });
+});


### PR DESCRIPTION
- Closes #211 

This PR creates simple tests for the Burner Wallet connector in the react-app.
The tests are only regarding stability of the connection. No transfer and increment tests are done at this moment.

Tests:
- [x] should connect and show fuel address
- [x] should connect, disconnect, and reconnect
- [x] should connect, refresh and stay connected
- [x] should connect, disconnect, refresh and stay disconnected