### PR TITLE
feat: add skip auto reconnect

### DIFF
--- a/.changeset/strong-bugs-remain.md
+++ b/.changeset/strong-bugs-remain.md
@@ -1,0 +1,6 @@
+---
+"@fuel-connectors/walletconnect-connector": minor
+"@fuels/connectors": minor
+---
+
+feat: added `skipAutoReconnect` to avoid WalletConnectConnector reconnecting automatically over the Wagmi already reconnected

--- a/packages/connectors/src/defaultConnectors.ts
+++ b/packages/connectors/src/defaultConnectors.ts
@@ -18,6 +18,7 @@ type DefaultConnectors = {
   wcProjectId?: string;
   burnerWalletConfig?: BurnerWalletConfig;
   ethWagmiConfig?: Config;
+  ethSkipAutoReconnect?: boolean;
   solanaConfig?: ProviderType;
   chainId?: number;
   fuelProvider?: FuelProvider | Promise<FuelProvider>;
@@ -28,6 +29,7 @@ export function defaultConnectors({
   wcProjectId,
   burnerWalletConfig,
   ethWagmiConfig,
+  ethSkipAutoReconnect,
   solanaConfig: _solanaConfig,
   chainId,
   fuelProvider,
@@ -41,6 +43,7 @@ export function defaultConnectors({
       wagmiConfig: ethWagmiConfig,
       chainId,
       fuelProvider,
+      skipAutoReconnect: ethSkipAutoReconnect,
     }),
     new SolanaConnector({
       projectId: wcProjectId,

--- a/packages/walletconnect-connector/src/WalletConnectConnector.ts
+++ b/packages/walletconnect-connector/src/WalletConnectConnector.ts
@@ -202,10 +202,11 @@ export class WalletConnectConnector extends PredicateConnector {
   protected async requireConnection() {
     const wagmiConfig = this.getWagmiConfig();
     if (!this.web3Modal) this.createModal();
-    if (!wagmiConfig) return;
 
-    const { state } = wagmiConfig;
-    if (state.status === 'disconnected' && state.connections.size > 0) {
+    if (this.config.skipAutoReconnect || !wagmiConfig) return;
+
+    const { status, connections } = wagmiConfig.state;
+    if (status === 'disconnected' && connections.size > 0) {
       await reconnect(wagmiConfig);
     }
   }

--- a/packages/walletconnect-connector/src/types.ts
+++ b/packages/walletconnect-connector/src/types.ts
@@ -9,4 +9,6 @@ export type WalletConnectConfig = {
   predicateConfig?: PredicateConfig;
   storage?: StorageAbstract;
   chainId?: number;
+  // if the dapp already has wagmi from eth connectors, it's better to skip auto reconnection as it can lead to session loss when refreshing the page
+  skipAutoReconnect?: boolean;
 };


### PR DESCRIPTION
## Problem
When you have wagmi provider configured on the dapp, the reconnection of the Fuel Connector may conflict with reconnection of Wagmi, causing flaky loss of section across refreshs.

## Solution
Skip the auto reconnect step on WalletConnectConnector, this way we let the responsibility of recovering session after refresh for Wagmi, which will do it anyway.