### PR TITLE
docs(e2e): Add instructions and command for running tests locally FE-897

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,84 @@ console.log(connection);
 pnpm build
 ```
 
+## Running E2E Tests Locally
+
+The `fuel-connectors` project includes comprehensive end-to-end (E2E) tests to ensure robust functionality across all connectors. Follow the steps below to set up and run these tests locally.
+
+### Prerequisites
+
+Ensure you have the following installed on your system:
+
+1. **Docker**: For running required services.
+2. **Node.js (v20.11.0 or higher)**: Use the version specified in `.nvmrc` or the project configuration.
+3. **PNPM**: Version `9.x` or higher. Install it globally if needed:
+   ```bash
+   npm install -g pnpm
+   ```
+
+---
+
+### Steps to Run E2E Tests
+
+1. **Install Dependencies**
+
+   Navigate to the project root and install all dependencies:
+   ```bash
+   pnpm install
+   ```
+
+2. **Start the Local Test Node**
+
+   Bring up the test node services using Docker:
+   ```bash
+   pnpm node:up
+   ```
+
+3. **Run E2E Tests**
+
+   Run the full E2E test suite:
+   ```bash
+   pnpm test:e2e:local
+   ```
+
+   This script performs the following:
+   - Deploys required contracts.
+   - Starts the React and Next.js test servers.
+   - Executes Playwright tests across all connectors.
+
+---
+
+### Additional Commands
+
+- **Run Tests for Specific Connectors**  
+  To run tests for an individual project:
+  ```bash
+  pnpm --filter @e2e-tests/runner test:react-app
+  ```
+React App is faster to build for e2e development.
+
+- **Debug with Playwright UI**  
+  Use Playwright's interactive UI for debugging tests:
+  ```bash
+  pnpm --filter @e2e-tests/runner test:e2e:ui
+  ```
+
+- **Stop the Local Test Node**  
+  After testing, stop the test node to free up resources:
+  ```bash
+  pnpm node:down
+  ```
+
+---
+
+### Troubleshooting
+
+- **Port Conflicts**  
+  If you encounter errors related to ports already in use, ensure no processes are running on the following ports:
+  - `4000`: Fuel Provider
+  - `5173`: React App
+  - `3002`: Next.js App
+
 ## 📜 License
 
 This repo is licensed under the `Apache-2.0` license. See [`LICENSE`](./LICENSE) for more information.

--- a/e2e-tests/runner/package.json
+++ b/e2e-tests/runner/package.json
@@ -9,9 +9,7 @@
   "scripts": {
     "test:e2e": "pnpm run start:servers & pnpm exec playwright test",
     "test:e2e:ui": "playwright test --ui --debug",
-    "test:react-app": "pnpm test:react-app:ci -- --ui",
-    "test:react-app:ci": "playwright test e2e-tests/react-app --project=react-app",
-    "test:react-next": "pnpm playwright test --project=react-next",
+    "test:e2e:local": "pnpm run deploy:contracts && pnpm run test:e2e",
     "start:react-app": "pnpm --filter react-app dev",
     "start:react-next": "pnpm --filter @e2e-tests/react-next dev",
     "start:servers": "pnpm run start:react-app & pnpm run start:react-next",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "node:clean": "make -C ./docker clean",
     "test:ci": "turbo run test -- --run --coverage.enabled --coverage.reporter=json-summary --coverage.reporter=json",
     "test:e2e": "turbo run test:e2e",
-    "test:e2e:local": "pnpm --filter @e2e-tests/runner test:e2e:local",
+    "test:e2e:local": "turbo run test:e2e:local --filter @e2e-tests/runner",
     "lint:check": "biome check --apply-unsafe .",
     "lint:ci": "biome lint --max-diagnostics=1000 --diagnostic-level=error .",
     "format": "biome format --write .",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "node:clean": "make -C ./docker clean",
     "test:ci": "turbo run test -- --run --coverage.enabled --coverage.reporter=json-summary --coverage.reporter=json",
     "test:e2e": "turbo run test:e2e",
+    "test:e2e:local": "pnpm --filter @e2e-tests/runner test:e2e:local",
     "lint:check": "biome check --apply-unsafe .",
     "lint:ci": "biome lint --max-diagnostics=1000 --diagnostic-level=error .",
     "format": "biome format --write .",

--- a/turbo.json
+++ b/turbo.json
@@ -26,6 +26,9 @@
     },
     "test:e2e": {
       "cache": false
+    },
+    "test:e2e:local": {
+      "cache": false
     }
   }
 }


### PR DESCRIPTION
### Summary
This PR updates the documentation and provides a new script command to simplify the process of running end-to-end (E2E) tests locally.

### Changes
- Updated the README to include detailed steps for running E2E tests locally.
- Added a new npm script command to streamline the local testing setup.

### New Script
```
pnpm test:e2e
```

### Tasks Completed
- [x] Updated README with clear local testing instructions.
- [x] Added a convenient script for running E2E tests locally.