### PR TITLE
chore(e2e): remove build script from package.json

### DIFF
--- a/e2e-tests/react-next/package.json
+++ b/e2e-tests/react-next/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "scripts": {
     "dev": "next dev -p 3002",
-    "build": "next build",
     "start": "next start"
   },
   "dependencies": {


### PR DESCRIPTION
Turbo was breaking main release
```
"build": {
      "dependsOn": ["^build"],
      "outputs": ["dist/**"]
```