### PR TITLE
Fix typo Update README.md

### DIFF
--- a/packages/evm-predicates/predicate/README.md
+++ b/packages/evm-predicates/predicate/README.md
@@ -4,7 +4,7 @@ The predicate is employed to authenticate that the signer in a transaction corre
 
 ## Building the projects
 
-Prerequsite: have `forc` installed.
+Prerequisite: have `forc` installed.
 
 In the root of the repository run
 


### PR DESCRIPTION
# Fix Typo in `README.md`

## Description
This pull request corrects a typo in the `README.md` file. The word "Prerequsite" was corrected to "Prerequisite."

## Changes
- Fixed the typo "Prerequsite" to "Prerequisite" in the "Building the projects" section.

