### PR TITLE
fix: on new helper methods, sort evm/svm predicates by more recent first

### DIFF
--- a/.changeset/cool-deers-love.md
+++ b/.changeset/cool-deers-love.md
@@ -1,0 +1,6 @@
+---
+"@fuel-connectors/walletconnect-connector": patch
+"@fuel-connectors/solana-connector": patch
+---
+
+fix: sort evm/svm predicates by most recent first on the new helper methods

--- a/packages/solana-connector/src/SolanaConnector.ts
+++ b/packages/solana-connector/src/SolanaConnector.ts
@@ -284,21 +284,22 @@ export class SolanaConnector extends PredicateConnector {
   }
 
   static getFuelPredicateAddresses(svmAddress: string) {
-    const predicateConfig = Object.entries(PREDICATE_VERSIONS).map(
-      ([svmPredicateAddress, { predicate, generatedAt }]) => ({
+    const predicateConfig = Object.entries(PREDICATE_VERSIONS)
+      .sort(([, a], [, b]) => b.generatedAt - a.generatedAt)
+      .map(([svmPredicateAddress, { predicate, generatedAt }]) => ({
         abi: predicate.abi,
         bin: predicate.bin,
         svmPredicate: {
           generatedAt,
           address: svmPredicateAddress,
         },
-      }),
-    );
+      }));
 
+    const address = new SolanaWalletAdapter().convertAddress(svmAddress);
     const predicateAddresses = predicateConfig.map(
       ({ abi, bin, svmPredicate }) => ({
         fuelAddress: getFuelPredicateAddresses({
-          signerAddress: new SolanaWalletAdapter().convertAddress(svmAddress),
+          signerAddress: address,
           predicate: { abi, bin },
         }),
         svmPredicate,

--- a/packages/walletconnect-connector/src/WalletConnectConnector.ts
+++ b/packages/walletconnect-connector/src/WalletConnectConnector.ts
@@ -503,21 +503,22 @@ export class WalletConnectConnector extends PredicateConnector {
   }
 
   static getFuelPredicateAddresses(ethAddress: string) {
-    const predicateConfig = Object.entries(PREDICATE_VERSIONS).map(
-      ([evmPredicateAddress, { predicate, generatedAt }]) => ({
+    const predicateConfig = Object.entries(PREDICATE_VERSIONS)
+      .sort(([, a], [, b]) => b.generatedAt - a.generatedAt)
+      .map(([evmPredicateAddress, { predicate, generatedAt }]) => ({
         abi: predicate.abi,
         bin: predicate.bin,
         evmPredicate: {
           generatedAt,
           address: evmPredicateAddress,
         },
-      }),
-    );
+      }));
 
+    const address = new EthereumWalletAdapter().convertAddress(ethAddress);
     const predicateAddresses = predicateConfig.map(
       ({ abi, bin, evmPredicate }) => ({
         fuelAddress: getFuelPredicateAddresses({
-          signerAddress: new EthereumWalletAdapter().convertAddress(ethAddress),
+          signerAddress: address,
           predicate: { abi, bin },
         }),
         evmPredicate,


### PR DESCRIPTION
# Summary
Order the svm/evm predicates by most recent first on the new helper methods 

# Checklist

- [x] I've added error handling for all actions/requests, and verified how this error will show on UI. (or there was no error handling)
- [x] I've reviewed all the copy changed/added in this PR, using AI if needed. (or there was no copy changes)
- [x] I've included the reference to the issues being closed from Github and/or Linear (or there was no issues)
- [x] I've changed the Docs to reflect my changes (or it was not needed)
- [x] I've put docs links where it may be helpful (or it was not needed)
- [x] I checked the resulting UI both in Light and Dark mode (or no UI changes were made)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
