### PR TITLE
fix: predicate selection logic consider balances instead of eth balance only

### DIFF
--- a/.changeset/afraid-foxes-cough.md
+++ b/.changeset/afraid-foxes-cough.md
@@ -1,0 +1,5 @@
+---
+"@fuel-connectors/common": patch
+---
+
+fix: predicate selection logic consider balances instead of eth balance only

--- a/packages/common/src/PredicateConnector.ts
+++ b/packages/common/src/PredicateConnector.ts
@@ -116,9 +116,8 @@ export abstract class PredicateConnector extends FuelConnector {
       const { fuelProvider } = await this.getProviders();
       const predicate = predicateInstance.build(address, fuelProvider, [1]);
 
-      const balance = await predicate.getBalance();
-
-      if (!balance.isZero()) {
+      const { balances } = await predicate.getBalances();
+      if (balances?.length > 0) {
         return predicateInstance;
       }
     }

--- a/packages/walletconnect-connector/src/WalletConnectConnector.ts
+++ b/packages/walletconnect-connector/src/WalletConnectConnector.ts
@@ -410,21 +410,8 @@ export class WalletConnectConnector extends PredicateConnector {
     params?: FuelConnectorSendTxParams,
   ): Promise<string> {
     const { ethProvider, fuelProvider } = await this.getProviders();
-    console.log('asd inputs BEFORE prepare', transaction.inputs?.toString());
-    console.log(
-      'asd witnesses BEFORE prepare',
-      transaction.witnesses?.toString(),
-    );
     const { request, transactionId, account, transactionRequest } =
       await this.prepareTransaction(address, transaction);
-    console.log(
-      'asd inputs AFTER prepare',
-      transactionRequest.inputs?.toString(),
-    );
-    console.log(
-      'asd witnesses AFTER prepare',
-      transactionRequest.witnesses?.toString(),
-    );
 
     const txId = this.encodeTxId(transactionId);
     const signature = (await ethProvider?.request({
@@ -439,12 +426,6 @@ export class WalletConnectConnector extends PredicateConnector {
     // Transform the signature into compact form for Sway to understand
     const compactSignature = splitSignature(hexToBytes(signature)).compact;
 
-    console.log('asd predicateSignatureIndex', predicateSignatureIndex);
-    console.log(
-      'asd transactionRequest.witnesses',
-      transactionRequest.witnesses?.toString(),
-    );
-    console.log('asd compactSignature', compactSignature);
     transactionRequest.witnesses[predicateSignatureIndex] = compactSignature;
 
     const transactionWithPredicateEstimated =


### PR DESCRIPTION


- Closes #490 
- Closes FE-1515

# Summary
The logic to detect the current predicate address was using only ETH balance in consideration. Now it's considering also another balances

# Checklist

- [x] I've added error handling for all actions/requests, and verified how this error will show on UI. (or there was no error handling)
- [x] I've reviewed all the copy changed/added in this PR, using AI if needed. (or there was no copy changes)
- [x] I've included the reference to the issues being closed from Github and/or Linear (or there was no issues)
- [x] I've changed the Docs to reflect my changes (or it was not needed)
- [x] I've put docs links where it may be helpful (or it was not needed)
- [x] I checked the resulting UI both in Light and Dark mode (or no UI changes were made)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
