### PR TITLE
feat: release pr tag on npm aws registry

### DIFF
--- a/.github/workflows/pr-release.yaml
+++ b/.github/workflows/pr-release.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
-          aws-region: ${{ vars.AWS_S3_REGION }}
+          aws-region: us-east-1
 
       - name: Create .npmrc
         run: |

--- a/.github/workflows/pr-release.yaml
+++ b/.github/workflows/pr-release.yaml
@@ -54,11 +54,11 @@ jobs:
       - name: Release PR version
         id: release
         run: |
+          pnpm changeset:next
           pnpm changeset version --snapshot pr-${{ github.event.pull_request.number }}
           changetsets=$(pnpm changeset publish --tag pr-${{ github.event.pull_request.number }})
           echo "BUILD_VERSION=$(pnpm -s packages:version)" >> $GITHUB_ENV
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOME: ${{ github.workspace }}
           npm_config_registry: "https://fuel-024848458133.d.codeartifact.us-east-1.amazonaws.com/npm/npm/"
 

--- a/.github/workflows/pr-release.yaml
+++ b/.github/workflows/pr-release.yaml
@@ -27,10 +27,6 @@ jobs:
           node-version: 20.11.0
           pnpm-version: 9.5.0
 
-      - uses: FuelLabs/github-actions/setups/npm@master
-        with:
-          npm-token: ${{ secrets.NPM_TOKEN_CONNECTORS }}
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -62,7 +58,6 @@ jobs:
           changetsets=$(pnpm changeset publish --tag pr-${{ github.event.pull_request.number }})
           echo "BUILD_VERSION=$(pnpm -s packages:version)" >> $GITHUB_ENV
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_CONNECTORS }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOME: ${{ github.workspace }}
           npm_config_registry: "https://fuel-024848458133.d.codeartifact.us-east-1.amazonaws.com/npm/npm/"

--- a/.github/workflows/pr-release.yaml
+++ b/.github/workflows/pr-release.yaml
@@ -14,9 +14,8 @@ concurrency:
 jobs:
   pr-release:
     name: Release PR to NPM
-    if: false
     runs-on: buildjet-4vcpu-ubuntu-2204
-    environment: npm-deploy
+    permissions: write-all
     steps:
       - uses: actions/checkout@v3
         with:
@@ -32,6 +31,25 @@ jobs:
         with:
           npm-token: ${{ secrets.NPM_TOKEN_CONNECTORS }}
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_S3_REGION }}
+
+      - name: Create .npmrc
+        run: |
+          TOKEN=$(aws codeartifact get-authorization-token \
+            --domain fuel \
+            --domain-owner 024848458133 \
+            --query authorizationToken \
+            --output text)
+
+          echo "//fuel-024848458133.d.codeartifact.us-east-1.amazonaws.com/npm/npm/:always-auth=true" >> $HOME/.npmrc
+          echo "//fuel-024848458133.d.codeartifact.us-east-1.amazonaws.com/npm/npm/:_authToken=${TOKEN}" >> $HOME/.npmrc
+        env:
+          HOME: ${{ github.workspace }}
+
       - name: Build Lib
         run: pnpm build
         env:
@@ -46,6 +64,8 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_CONNECTORS }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOME: ${{ github.workspace }}
+          npm_config_registry: "https://fuel-024848458133.d.codeartifact.us-east-1.amazonaws.com/npm/npm/"
 
       - name: Comment release package name to PR
         uses: mshick/add-pr-comment@v2


### PR DESCRIPTION
- Closes #494 
- Closes FE-1518

# Summary
Change our `release PR to npm` action to use aws npm registry instead of npm directly.

# Checklist

- [x] I've added error handling for all actions/requests, and verified how this error will show on UI. (or there was no error handling)
- [x] I've reviewed all the copy changed/added in this PR, using AI if needed. (or there was no copy changes)
- [x] I've included the reference to the issues being closed from Github and/or Linear (or there was no issues)
- [x] I've changed the Docs to reflect my changes (or it was not needed)
- [x] I've put docs links where it may be helpful (or it was not needed)
- [x] I checked the resulting UI both in Light and Dark mode (or no UI changes were made)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
