### PR TITLE
feat: support Fuelet depplinks

### DIFF
--- a/packages/fuelet-wallet/src/FueletWalletConnector.ts
+++ b/packages/fuelet-wallet/src/FueletWalletConnector.ts
@@ -69,4 +69,31 @@ export class FueletWalletConnector extends FuelWalletConnector {
 
     return super.currentAccount();
   }
+
+  isMobile() {
+    return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini|Mobile|mobile|CriOS/i.test(
+      navigator.userAgent,
+    );
+  }
+
+  isFueletWebView() {
+    return /FueletMobileApp/i.test(navigator.userAgent);
+  }
+
+  isMobileNativeBrowser() {
+    return !this.isFueletWebView() && this.isMobile();
+  }
+
+  async connect() {
+    if (this.isMobileNativeBrowser()) {
+      window.location.href = `app.fuelet://browser?url=${window.location.href}&action=connect`;
+      // we don't connect the wallet in the browser but redirect to the mobile app
+      return false;
+    }
+    return super.connect();
+  }
+
+  async ping() {
+    return this.isMobileNativeBrowser() || (await super.ping());
+  }
 }

--- a/packages/react/src/ui/Connect/components/Connectors/ConnectorBadge.tsx
+++ b/packages/react/src/ui/Connect/components/Connectors/ConnectorBadge.tsx
@@ -3,6 +3,20 @@ import { useMemo } from 'react';
 import { NATIVE_CONNECTORS } from '../../../../config';
 import { BadgeInfo, BadgeSuccess } from './styles';
 
+function isMobile() {
+  return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini|Mobile|mobile|CriOS/i.test(
+    navigator.userAgent,
+  );
+}
+
+function isFueletWebView() {
+  return /FueletMobileApp/i.test(navigator.userAgent);
+}
+
+function isFueletConnectorOnMobileBrowser(connectorName: string) {
+  return connectorName === 'Fuelet Wallet' && isMobile() && !isFueletWebView();
+}
+
 interface ConnectorBadgeProps {
   name: FuelConnector['name'];
   connected: FuelConnector['connected'];
@@ -22,7 +36,7 @@ export function ConnectorBadge({
     return <BadgeSuccess>Connected</BadgeSuccess>;
   }
 
-  if (!isBlacklisted && installed) {
+  if (!isBlacklisted && installed && !isFueletConnectorOnMobileBrowser(name)) {
     return <BadgeInfo>Installed</BadgeInfo>;
   }
 


### PR DESCRIPTION
# Summary
Added support for Fuelet deeplinks on mobile devices.

That's a further development of https://github.com/FuelLabs/fuel-connectors/pull/488.

Mobile deeplinks lack the capability to verify whether an app is installed on the device. Consequently, we always assume the Fuelet connector is present in mobile browsers and attempt to open its deeplink during connection. If the app isn’t installed, a system error is displayed. 

Uniswap and uniswap wallet work the same way on https://app.uniswap.org/swap:
<img src="https://github.com/user-attachments/assets/3aff9a29-458b-4a07-94d5-f65f7ebd18af" alt="Uniswap example" width="200">

Also removed the "installed" badge from the Fuelet connector on mobile browsers in order to avoid confusion for cases when the app is not installed.

For context:
- native mobile browser - browsers such as Safari or Chrome installed on a mobile device
- Fuelet webview - a built-in browser to Fuelet mobile app (accessible via the browser tab)

Both browsers use different communication channels with Fuelet, hence require a different processing

Deeplinks have not been released in Fuelet yet, corresponding changes are currently in review in android and apple stores (will be released soon).
