### PR TITLE
chore: update changeset configuration to include @e2e-tests/runner 

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,7 +9,14 @@
     { "repo": "FuelLabs/fuel-connectors" }
   ],
   "commit": false,
-  "fixed": [["@fuels/connectors", "@fuel-connectors/*", "@fuels/react"]],
+  "fixed": [
+    [
+      "@fuels/connectors",
+      "@fuel-connectors/*",
+      "@fuels/react",
+      "@e2e-tests/runner"
+    ]
+  ],
   "linked": [],
   "access": "public",
   "baseBranch": "main",


### PR DESCRIPTION

# Summary

This PR updates the version in `e2e-tests/runner/package.json` to align it with the rest of the monorepo packages. This is a maintenance change for consistency and does not impact any published or user-facing code.

# Breaking Changes

_None._

# Checklist

- [ ] I've added error handling for all actions/requests, and verified how this error will show on UI. (or there was no error handling)
- [ ] I've reviewed all the copy changed/added in this PR, using AI if needed. (or there was no copy changes)
- [ ] I checked the resulting UI both in Light and Dark mode (or no UI changes were made)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)