### PR TITLE
Fix typo in BakoSafeConnector and update README in evm-predicates

### DIFF
--- a/packages/bako-safe/src/BakoSafeConnector.ts
+++ b/packages/bako-safe/src/BakoSafeConnector.ts
@@ -111,7 +111,7 @@ export class BakoSafeConnector extends FuelConnector {
 
     // timeout to close
     const interval = setInterval(() => {
-      const isOpen = this.dAppWindow?.opned?.closed;
+      const isOpen = this.dAppWindow?.opened?.closed;
       if (isOpen) {
         this.emit(BakoSafeConnectorEvents.CLIENT_DISCONNECTED, {});
         clearInterval(interval);

--- a/packages/evm-predicates/predicate/README.md
+++ b/packages/evm-predicates/predicate/README.md
@@ -4,7 +4,7 @@ The predicate is employed to authenticate that the signer in a transaction corre
 
 ## Building the projects
 
-Prerequsite: have `forc` installed.
+Prerequisite: have `forc` installed.
 
 In the root of the repository run
 


### PR DESCRIPTION


---

**Description:**  
- Fixed a typo in the BakoSafeConnector (`isOpen` variable assignment).
- Minor formatting improvement in the `evm-predicates/predicate/README.md` (prerequisite section).


---